### PR TITLE
ci: automate categorized release notes

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,35 @@
+# Pull requests and releases
+
+Submit related changes as separate PRs. Stacked PRs target the branch below them; CI runs for
+every PR base, not just `main`. Merge the approved stack bottom-up so each PR lands on `main`.
+
+Use a conventional-commit PR title, `type(scope): description`, and a matching type label:
+
+- `feat`: New Features
+- `fix`: Bug Fixes
+- `perf`: Performance
+- `refactor`: Refactoring
+- `docs`: Documentation
+- `build`, `chore`, `ci`, `revert`, or `test`: Other Changes
+
+For example, `fix(client): recover failed navigation` gets the `fix` label. For breaking changes,
+use `!` in the title, such as `feat!: change the Page contract`, and add the `breaking` label
+alongside the type label. Breaking Changes takes precedence over the type category.
+
+GitHub groups entries by labels, not by parsing titles; keep both aligned. Uncategorized PRs appear
+under Other Changes. The categories live in [release.yml](release.yml); no title parser or changelog
+dependency is needed.
+
+## Publishing
+
+1. Merge the release's PRs into `main`, including the matching framework, scaffolder, and template
+   version updates. Update local `main` to match GitHub.
+2. Run `bun run release <version>`. The existing script verifies the repository, asks for
+   confirmation, publishes both npm packages, and pushes the version tag.
+3. The [release-notes workflow](workflows/release-notes.yml) creates a draft GitHub release with
+   automatically generated PR entries, contributors, and a comparison link.
+4. Review the draft and publish it on GitHub.
+
+Pushing a branch or opening a PR does not create a release. The notes workflow does not publish
+npm packages or create tags. It requires the tag to exist and does not overwrite an existing
+release when rerun.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  categories:
+    - title: Breaking Changes 🍭
+      labels:
+        - breaking
+    - title: New Features 🎉
+      labels:
+        - feat
+    - title: Performance 🚀
+      labels:
+        - perf
+    - title: Bug Fixes 🐞
+      labels:
+        - fix
+    - title: Refactoring 🔨
+      labels:
+        - refactor
+    - title: Documentation 📖
+      labels:
+        - docs
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: bun run check
 
       - name: Install Playwright browser
-        run: bunx playwright install --with-deps chromium
+        run: bun run playwright install --with-deps chromium
 
       - name: Test
         run: bun run test

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,25 @@
+name: Release notes
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release-notes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Create draft release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$RELEASE_TAG" \
+            --verify-tag \
+            --title "$RELEASE_TAG" \
+            --draft \
+            --generate-notes

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "effective-rsc-monorepo",
       "devDependencies": {
         "@effect/tsgo": "0.41.0",
+        "@playwright/test": "catalog:",
         "@types/bun": "catalog:",
         "oxfmt": "^0.66.0",
         "oxlint": "1.81.0",
@@ -594,7 +595,7 @@
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -782,13 +783,13 @@
 
     "lucide-react/react": ["react@19.3.0-canary-eb8feb71-20260814", "", {}, "sha512-4CF6VVbInQ54749LzFJ6POm1SREXQmNZ6yFjTq67yCL3NrYlK+aO6nzO3i1Fe7szu/fXUr3NRzitdHj+l/O5EQ=="],
 
-    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
     "react-server-dom-rspack/react": ["react@19.3.0-canary-eb8feb71-20260814", "", {}, "sha512-4CF6VVbInQ54749LzFJ6POm1SREXQmNZ6yFjTq67yCL3NrYlK+aO6nzO3i1Fe7szu/fXUr3NRzitdHj+l/O5EQ=="],
 
     "react-server-dom-rspack/react-dom": ["react-dom@19.3.0-canary-eb8feb71-20260814", "", { "dependencies": { "scheduler": "0.28.0-canary-eb8feb71-20260814" }, "peerDependencies": { "react": "19.3.0-canary-eb8feb71-20260814" } }, "sha512-sURKF6v4XliFLgl9+lT3S9zM9EEqJFDzYwE7+BtHdUesovByKQbM9dm4WqGr/b3kiTq6jw7ASIYG10j/t2pbbQ=="],
 
     "use-sync-external-store/react": ["react@19.3.0-canary-eb8feb71-20260814", "", {}, "sha512-4CF6VVbInQ54749LzFJ6POm1SREXQmNZ6yFjTq67yCL3NrYlK+aO6nzO3i1Fe7szu/fXUr3NRzitdHj+l/O5EQ=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@base-ui/react/react-dom/scheduler": ["scheduler@0.28.0-canary-eb8feb71-20260814", "", {}, "sha512-TjXQVWDPcNnqesHvbi5WB587WPFr8to90JVhOIO0szb0GFgg0fF0PPJCWoxi0poyxJ98OThXb22akDHfZyXG6A=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@effect/tsgo": "0.41.0",
+    "@playwright/test": "catalog:",
     "@types/bun": "catalog:",
     "oxfmt": "^0.66.0",
     "oxlint": "1.81.0",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -73,4 +73,4 @@ bun publish --cwd packages/create-ersc-app
 git tag --annotate "$tag" --message "Release $version"
 git push origin "$tag"
 
-echo "Create the GitHub release for $tag: https://github.com/nikhilsnayak/effective-rsc/releases/new"
+echo "GitHub Actions will generate a draft release for $tag. Review and publish it at https://github.com/nikhilsnayak/effective-rsc/releases"


### PR DESCRIPTION
- Generate draft release notes from conventional PR labels when a version tag is pushed.
- Run CI for PRs targeting any branch.
- Install browsers using the locked Playwright version.