### PR TITLE
fix(client): prevent refresh deadlocks and stale action updates

### DIFF
--- a/docs/architecture/client-router.md
+++ b/docs/architecture/client-router.md
@@ -62,8 +62,9 @@ calling React's `addTransitionType()` inside the same `startTransition()` callba
 the corresponding render.
 
 This placement is significant. Routed Flight and current-route refreshes load asynchronously, so
-adding types only to the outer async Action would not associate them with the later UI update. The
-nested publication Transition adds the types immediately before calling `BrowserRenderer`.
+adding types before loading would not associate them with the later UI update. The publication
+Transition adds the types immediately before calling `BrowserRenderer`. Effect owns loading and
+cleanup; the Transition callback does not return a Promise waiting for its own React commit.
 
 Transition types are additive:
 

--- a/docs/architecture/request-flows.md
+++ b/docs/architecture/request-flows.md
@@ -61,7 +61,8 @@ waiting for suspended route content.
 Hydrated invocations may execute concurrently. Only the latest invocation may apply its embedded
 route tree while its original history entry remains current and no navigation is active. Other
 responses trigger a fresh current-route refresh. Applying an embedded tree interrupts any older
-current-route refresh first.
+current-route refresh first, then rechecks invocation ordering, the current entry, and active
+navigation after that interruption finishes and before publishing.
 
 Progressive form submission uses the same native protocol and returns a redirect to the current
 route. The browser then performs an ordinary document request.

--- a/packages/effective-rsc/LLMS.md
+++ b/packages/effective-rsc/LLMS.md
@@ -243,7 +243,9 @@ Flight EOF. Disconnecting interrupts unfinished request work and the response st
 Hydrated invocations may execute concurrently. Only the latest invocation may apply its response's
 route tree while its original history entry remains current and no navigation is active. Other
 responses trigger a fresh current-route refresh. A response tree interrupts any older current-route
-refresh before rendering.
+refresh before rendering, then rechecks applicability after cleanup completes. Effect owns refresh
+loading and cancellation; the React Transition publishes the tree without waiting for its own
+commit inside an async Action.
 
 After a successful mutation, ERSC clears the Back/Forward traversal cache because any route may have
 changed.

--- a/packages/effective-rsc/docs/03-advanced/03-server-function-execution-and-refresh/index.md
+++ b/packages/effective-rsc/docs/03-advanced/03-server-function-execution-and-refresh/index.md
@@ -11,7 +11,9 @@ Flight EOF. Disconnecting interrupts unfinished request work and the response st
 Hydrated invocations may execute concurrently. Only the latest invocation may apply its response's
 route tree while its original history entry remains current and no navigation is active. Other
 responses trigger a fresh current-route refresh. A response tree interrupts any older current-route
-refresh before rendering.
+refresh before rendering, then rechecks applicability after cleanup completes. Effect owns refresh
+loading and cancellation; the React Transition publishes the tree without waiting for its own
+commit inside an async Action.
 
 After a successful mutation, ERSC clears the Back/Forward traversal cache because any route may have
 changed.

--- a/packages/effective-rsc/src/client/call-server.ts
+++ b/packages/effective-rsc/src/client/call-server.ts
@@ -125,13 +125,18 @@ export const installCallServer = Effect.gen(function* () {
         () => undefined,
       ),
     );
-    if (selectRefreshSource(invocation) === 'CurrentRoute') {
+    let refreshSource = selectRefreshSource(invocation);
+    if (refreshSource === 'Response') {
+      yield* routeRefresher.interruptCurrentRouteRefresh;
+      // Interruption awaits cleanup, during which navigation or another invocation can win.
+      refreshSource = selectRefreshSource(invocation);
+    }
+
+    if (refreshSource === 'CurrentRoute') {
       yield* resource.release;
       yield* routeRefresher.refreshCurrentRoute('server-function');
       return;
     }
-
-    yield* routeRefresher.interruptCurrentRouteRefresh;
     const commitRefresh = routeLoader.prepareRefresh(resource.payload.routeTree);
     let renderCommitted!: Promise<void>;
     yield* Effect.sync(() => {

--- a/packages/effective-rsc/src/client/route-refresh.ts
+++ b/packages/effective-rsc/src/client/route-refresh.ts
@@ -1,17 +1,12 @@
-import { Context, Effect, FiberMap, Layer, Ref, Schema } from 'effect';
+import { Context, Effect, FiberMap, Layer, Ref } from 'effect';
 import { addTransitionType, startTransition } from 'react';
 
-import { BrowserEffectRunner } from './browser-effect-runner';
 import { BrowserRenderer } from './browser-renderer';
 import { NavigationApi } from './navigation-api';
 import { isRoutedNavigation, preserveRequestedHash } from './navigation-routing';
 import { RouteLoader } from './route-loader';
 
 const CurrentRouteRefreshKey = 'CurrentRouteRefresh';
-
-class RouteRefreshError extends Schema.TaggedError<RouteRefreshError>()('RouteRefreshError', {
-  cause: Schema.Defect(),
-}) {}
 
 export type RouteRefreshTransitionType = 'hmr-refresh' | 'server-function';
 
@@ -60,7 +55,6 @@ export const installRouteRefresh = Effect.gen(function* () {
   const navigationApi = yield* NavigationApi;
   const routeLoader = yield* RouteLoader;
   const routeRefresher = yield* RouteRefresher;
-  const run = yield* BrowserEffectRunner;
   const refreshes = yield* FiberMap.make<typeof CurrentRouteRefreshKey>();
 
   const waitForNavigationIdle = Effect.suspend(() => {
@@ -123,22 +117,15 @@ export const installRouteRefresh = Effect.gen(function* () {
     }).pipe(Effect.andThen(Effect.sync(commitRefresh)), Effect.ensuring(resource.release));
   });
 
-  const refreshInReactTransition = (transitionType: RouteRefreshTransitionType) =>
-    Effect.callback<void, RouteRefreshError>((resume, signal) => {
-      startTransition(() =>
-        run(refreshRoute(transitionType), { signal }).then(
-          () => resume(Effect.void),
-          (cause) => resume(Effect.fail(new RouteRefreshError({ cause }))),
-        ),
-      );
-    });
-
   const refreshCurrentRoute = Effect.fnUntraced(
     function* (transitionType: RouteRefreshTransitionType) {
       routeLoader.invalidate();
       yield* waitForNavigationIdle;
-      yield* Effect.raceFirst(refreshInReactTransition(transitionType), waitForRoutedNavigation);
+      // Only publication belongs to a React Transition. An async Action waiting for this
+      // effect would prevent the very UI commit that completes the refresh.
+      yield* Effect.raceFirst(refreshRoute(transitionType), waitForRoutedNavigation);
     },
+    Effect.scoped,
     Effect.catch((cause) => Effect.logError('Failed to refresh the current route.', cause)),
   );
 

--- a/packages/effective-rsc/tests/client/call-server.test.ts
+++ b/packages/effective-rsc/tests/client/call-server.test.ts
@@ -166,7 +166,10 @@ type TestNavigationState = {
   readonly transition: MutableRef.MutableRef<NavigationTransition | null>;
 };
 
-const staleResponseScenario = (changeNavigation: (state: TestNavigationState) => void) =>
+const staleResponseScenario = (
+  changeNavigation: (state: TestNavigationState) => void,
+  changeTiming: 'BeforeResponse' | 'DuringInterruption' = 'BeforeResponse',
+) =>
   Effect.scoped(
     Effect.gen(function* () {
       const response = yield* Deferred.make<ReturnType<typeof makeFlight>>();
@@ -212,7 +215,11 @@ const staleResponseScenario = (changeNavigation: (state: TestNavigationState) =>
         prepareRefresh: () => () => undefined,
       });
       const routeRefresherLayer = RouteRefresher.layerTest({
-        interruptCurrentRouteRefresh: Effect.void,
+        interruptCurrentRouteRefresh: Effect.sync(() => {
+          if (changeTiming === 'DuringInterruption') {
+            changeNavigation(navigationState);
+          }
+        }),
         refreshCurrentRoute: (transitionType) =>
           Effect.sync(() => refreshTransitionTypes.push(transitionType)).pipe(
             Effect.andThen(Deferred.succeed(currentRouteRefresh, undefined)),
@@ -232,7 +239,9 @@ const staleResponseScenario = (changeNavigation: (state: TestNavigationState) =>
 
       const result = invokeServerFn('first');
       yield* Deferred.await(requestStarted);
-      changeNavigation(navigationState);
+      if (changeTiming === 'BeforeResponse') {
+        changeNavigation(navigationState);
+      }
       yield* Deferred.succeed(response, makeFlight('stale', 'first result', Effect.sync(released)));
 
       const value = yield* Effect.promise(() => result);
@@ -251,6 +260,13 @@ const staleResponseScenario = (changeNavigation: (state: TestNavigationState) =>
 
 it.effect('refreshes the current route instead of applying a response from another entry', () =>
   staleResponseScenario(({ currentEntry }) => MutableRef.set(currentEntry, secondEntry)),
+);
+
+it.effect('rechecks the entry after awaiting older refresh cleanup', () =>
+  staleResponseScenario(
+    ({ currentEntry }) => MutableRef.set(currentEntry, secondEntry),
+    'DuringInterruption',
+  ),
 );
 
 it.effect('does not apply a Server Function response while navigation is in progress', () =>

--- a/packages/effective-rsc/tests/client/route-refresh.test.ts
+++ b/packages/effective-rsc/tests/client/route-refresh.test.ts
@@ -8,12 +8,19 @@ vi.mock('react-server-dom-rspack/client.browser', () => ({
 }));
 
 const react = vi.hoisted(() => ({
+  transitionResults: [] as Array<unknown>,
   transitionTypes: [] as Array<string>,
 }));
 
 vi.mock('react', (importOriginal) =>
   importOriginal<typeof import('react')>().then((original) => ({
     ...original,
+    startTransition: (action: Parameters<typeof original.startTransition>[0]) =>
+      original.startTransition(() => {
+        const result = action();
+        react.transitionResults.push(result);
+        return result;
+      }),
     addTransitionType: (type: string) => {
       react.transitionTypes.push(type);
     },
@@ -84,6 +91,7 @@ const makeNavigationApiLayer = (navigation: TestNavigation) =>
 const testHttpClient = HttpClient.make(() => Effect.die('Unexpected HTTP request.'));
 
 beforeEach(() => {
+  react.transitionResults.length = 0;
   react.transitionTypes.length = 0;
 });
 
@@ -203,6 +211,8 @@ it.effect('applies the HMR transition type after the active navigation settles',
 
         expect(nextRouteTree.id).toBe('refreshed');
         expect(react.transitionTypes).toEqual(['hmr-refresh']);
+        // Returning an async Action here would make React wait for its own UI commit.
+        expect(react.transitionResults).toEqual([undefined]);
         expect(invalidated).toHaveBeenCalledOnce();
         expect(navigation.navigate).not.toHaveBeenCalled();
         yield* Effect.yieldNow;


### PR DESCRIPTION
- Release the action response before refreshing the current route to prevent deadlocks.
- Ignore stale action responses after refresh cleanup.