### PR TITLE
fix(server): validate Server Function requests and document response behavior

### DIFF
--- a/docs/architecture/lifetimes-and-protocols.md
+++ b/docs/architecture/lifetimes-and-protocols.md
@@ -70,7 +70,7 @@ body limit is 10 MiB. Connection deadlines belong to the deployment in front of 
 | -------------------------------- | ------------------------------------ | --------------------------------- | ------------------------ |
 | Page GET/HEAD                    | Matched route scope                  | No                                | Yes                      |
 | Hydrated Server Function POST    | Remaining route scope around refresh | Server Function scope             | Yes                      |
-| Progressive Server Function POST | No route refresh in the POST         | Server Function scope             | Yes                      |
+| Progressive Server Function POST | Remaining route scope around refresh | Server Function scope             | Yes                      |
 | Userland HTTP, assets, unmatched | No                                   | No                                | Yes                      |
 
 Within one Server Function request, middleware already active in the Server Function scope is not

--- a/docs/architecture/request-flows.md
+++ b/docs/architecture/request-flows.md
@@ -65,8 +65,8 @@ responses trigger a fresh current-route refresh. Applying an embedded tree inter
 current-route refresh first, then rechecks invocation ordering, the current entry, and active
 navigation after that interruption finishes and before publishing.
 
-Progressive form submission uses the same native protocol and returns a redirect to the current
-route. The browser then performs an ordinary document request.
+Progressive form submission uses the same native protocol and returns a complete HTML document
+containing the refreshed route and React form state. It does not add a redirect or a second GET.
 
 Middleware captured by the Server Function surrounds its handler. Middleware already active for the
 Server Function is omitted from the refresh; the rest of the current route scope surrounds refreshed

--- a/docs/architecture/request-flows.md
+++ b/docs/architecture/request-flows.md
@@ -54,9 +54,10 @@ error handling.
 
 Hydrated calls use React's native Server Function POST. ERSC requires an Origin whose host matches
 the application host, enforces the body limit, decodes the reference and Schema input, runs the
-handler Effect, and starts the route refresh independently. The response carries the Server Function
-result and refreshed Flight through React's native protocol, allowing the result to settle without
-waiting for suspended route content.
+handler Effect, and starts the route refresh independently. React's decoded argument envelope must
+be an array; other decoded values are typed `400` failures before application invocation.
+The response carries the Server Function result and refreshed Flight through React's native
+protocol, allowing the result to settle without waiting for suspended route content.
 
 Hydrated invocations may execute concurrently. Only the latest invocation may apply its embedded
 route tree while its original history entry remains current and no navigation is active. Other

--- a/packages/effective-rsc/LLMS.md
+++ b/packages/effective-rsc/LLMS.md
@@ -320,10 +320,10 @@ middleware across mounted scopes runs once.
 | -------------------------------- | ------------------------------------ | --------------------- | ------------------------ |
 | Page GET/HEAD                    | Matched chain                        | No                    | Yes                      |
 | Hydrated Server Function POST    | Remaining route chain around refresh | Server Function chain | Yes                      |
-| Progressive Server Function POST | No route refresh in the POST         | Server Function chain | Yes                      |
+| Progressive Server Function POST | Remaining route chain around refresh | Server Function chain | Yes                      |
 | Userland HTTP, assets, unmatched | No                                   | No                    | Yes                      |
 
-During a hydrated Server Function request, middleware already active for the Server Function is not
+During a Server Function request, middleware already active for the Server Function is not
 executed again for the refreshed route, even if it appears at another position in that route chain.
 Remaining route middleware wraps refreshed rendering.
 

--- a/packages/effective-rsc/docs/04-api-reference/06-middleware/index.md
+++ b/packages/effective-rsc/docs/04-api-reference/06-middleware/index.md
@@ -22,10 +22,10 @@ middleware across mounted scopes runs once.
 | -------------------------------- | ------------------------------------ | --------------------- | ------------------------ |
 | Page GET/HEAD                    | Matched chain                        | No                    | Yes                      |
 | Hydrated Server Function POST    | Remaining route chain around refresh | Server Function chain | Yes                      |
-| Progressive Server Function POST | No route refresh in the POST         | Server Function chain | Yes                      |
+| Progressive Server Function POST | Remaining route chain around refresh | Server Function chain | Yes                      |
 | Userland HTTP, assets, unmatched | No                                   | No                    | Yes                      |
 
-During a hydrated Server Function request, middleware already active for the Server Function is not
+During a Server Function request, middleware already active for the Server Function is not
 executed again for the refreshed route, even if it appears at another position in that route chain.
 Remaining route middleware wraps refreshed rendering.
 

--- a/packages/effective-rsc/src/server/react-server-dom-rspack.d.ts
+++ b/packages/effective-rsc/src/server/react-server-dom-rspack.d.ts
@@ -22,7 +22,7 @@ declare module 'react-server-dom-rspack/server.node' {
       readonly arraySizeLimit?: number;
       readonly temporaryReferences?: TemporaryReferenceSet;
     },
-  ): Promise<ReadonlyArray<unknown>>;
+  ): Promise<unknown>;
 
   export function loadServerAction(actionId: string): (...args: ReadonlyArray<unknown>) => unknown;
 

--- a/packages/effective-rsc/src/server/server-fn-request.ts
+++ b/packages/effective-rsc/src/server/server-fn-request.ts
@@ -16,6 +16,7 @@ import type { RequestOutcome } from './request-outcome';
 import { serverFnOutcome } from './server-fn-outcome';
 
 const ServerFnArraySizeLimit = 10_000;
+const decodeArguments = Schema.decodeUnknownEffect(Schema.Array(Schema.Unknown));
 const NoMiddleware = Object.freeze([]);
 
 export class ServerFnRequestError extends Schema.TaggedError<ServerFnRequestError>()(
@@ -124,7 +125,7 @@ const prepareClientServerFn = Effect.fnUntraced(function* <ApplicationServices>(
 ) {
   const temporaryReferences = createTemporaryReferenceSet();
   const body = yield* readBody(request);
-  const args = yield* Effect.tryPromise({
+  const decoded = yield* Effect.tryPromise({
     try: () =>
       decodeReply(body, {
         arraySizeLimit: ServerFnArraySizeLimit,
@@ -132,6 +133,11 @@ const prepareClientServerFn = Effect.fnUntraced(function* <ApplicationServices>(
       }),
     catch: (cause) => requestError('Failed to decode Server Function arguments.', 400, cause),
   });
+  const args = yield* decodeArguments(decoded).pipe(
+    Effect.mapError((cause) =>
+      requestError('Expected a Server Function argument array.', 400, cause),
+    ),
+  );
   const action = yield* Effect.try({
     try: () => loadServerAction(actionId),
     catch: (cause) => requestError('The requested Server Function does not exist.', 400, cause),

--- a/packages/effective-rsc/tests/server/application.test.tsx
+++ b/packages/effective-rsc/tests/server/application.test.tsx
@@ -17,9 +17,7 @@ import { ServerConfig } from '../../src/server/server-config';
 const decodeAction = vi.fn((..._args: Array<unknown>): Promise<null | (() => Promise<string>)> =>
   Promise.resolve(null),
 );
-const decodeReply = vi.fn((..._args: Array<unknown>): Promise<ReadonlyArray<unknown>> =>
-  Promise.resolve([]),
-);
+const decodeReply = vi.fn((..._args: Array<unknown>): Promise<unknown> => Promise.resolve([]));
 let scopedServerAction: ((input: string) => Promise<string>) | undefined;
 
 vi.doMock('react-server-dom-rspack/server.node', () => ({
@@ -415,6 +413,19 @@ describe('ServerApplication.httpLayer', () => {
         expect(events).toEqual([]);
         expect(decodeAction).not.toHaveBeenCalled();
         expect(decodeReply).toHaveBeenCalledTimes(1);
+      }),
+    ),
+  );
+
+  it.effect('rejects decoded non-array action envelopes before invoking application code', () =>
+    withHarness(({ call, events }) =>
+      Effect.gen(function* () {
+        for (const envelope of [null, undefined, 'hello', 42, {}, { length: 1, 0: 'hello' }]) {
+          decodeReply.mockResolvedValueOnce(envelope);
+          const response = yield* call(serverFnRequest('scoped-action'));
+          expect(response.status).toBe(400);
+          expect(events).toEqual([]);
+        }
       }),
     ),
   );


### PR DESCRIPTION
- Validate decoded Server Function arguments before invoking the handler.
- Correct the docs for progressive form responses and middleware behavior.