### PR TITLE
fix(dev): cancel generation requests before disposing services

### DIFF
--- a/docs/architecture/build.md
+++ b/docs/architecture/build.md
@@ -34,13 +34,21 @@ resolves it by path.
 
 ## Development
 
-`ersc dev` watches the same browser and server compiler graphs. A successful generation atomically
-replaces the active server application. Browser updates use the compiler's HMR protocol; RSC changes
-refresh the current route through the Navigation API. A streaming Effect RPC carries development
+`ersc dev` watches the same browser and server compiler graphs. A replacement generation is fully
+initialized before it atomically becomes available to new requests. Admission waits for the current
+compilation outcome; compilation or startup failure rejects new requests instead of serving stale
+code. Successful replacement interrupts the previous generation's pending handlers and response
+streams before disposing its application services. Saving a file can therefore cut off an active
+response; development does not drain old generations or automatically retry Server Functions.
+Failed candidates leave the current generation's existing requests alone.
+Content-hashed development server bundles and chunks remain available for the development session.
+
+Browser updates use the compiler's HMR protocol; RSC changes refresh the current route through the
+Navigation API. A streaming Effect RPC carries development
 updates over `/_ersc/dev`. Development-only branches are removed from production builds. On
 shutdown, the development channel closes active WebSockets before stopping the Bun HTTP server, so
-connected browser tabs cannot retain the process. The channel accepts only WebSocket handshakes
-whose `Origin` matches the development server.
+connected browser tabs cannot retain the process. Request cleanup precedes disposal of generation
+services. The channel accepts only WebSocket handshakes whose `Origin` matches the development server.
 
 Development diagnostics start independently of hydration. Current-route refresh initially reloads
 the document; successful client-navigation activation replaces it with streamed RSC refresh.

--- a/docs/architecture/lifetimes-and-protocols.md
+++ b/docs/architecture/lifetimes-and-protocols.md
@@ -13,14 +13,15 @@ Bun server scope
       └─ response stream finalizers
 ```
 
-| Work                               | Owner                           | Completion or interruption                       |
-| ---------------------------------- | ------------------------------- | ------------------------------------------------ |
-| Application services               | Server scope                    | Server shutdown                                  |
-| HTTP and Server Function Effect    | Request fiber                   | Response completion, disconnect, or interruption |
-| Authored render Effects            | Request render-runtime FiberSet | Flight completion or request interruption        |
-| Preparing browser navigation       | Client-router candidate         | First UI commit, native abort, or supersession   |
-| Visible navigation Flight stream   | Client-router generation        | Flight EOF or renderer-confirmed retirement      |
-| Completed history-entry route tree | Browser route cache             | Cache invalidation or history-entry disposal     |
+| Work                               | Owner                           | Completion or interruption                             |
+| ---------------------------------- | ------------------------------- | ------------------------------------------------------ |
+| Application services               | Server scope                    | Server shutdown                                        |
+| Development generation services    | Generation scope                | Replacement or shutdown, after cancelling its requests |
+| HTTP and Server Function Effect    | Request fiber                   | Response completion, disconnect, or interruption       |
+| Authored render Effects            | Request render-runtime FiberSet | Flight completion or request interruption              |
+| Preparing browser navigation       | Client-router candidate         | First UI commit, native abort, or supersession         |
+| Visible navigation Flight stream   | Client-router generation        | Flight EOF or renderer-confirmed retirement            |
+| Completed history-entry route tree | Browser route cache             | Cache invalidation or history-entry disposal           |
 
 Effect interruption and Web Stream cancellation propagate across these boundaries. Work is not
 detached unless another explicit owner retains it.

--- a/packages/effective-rsc/src/build/dev.ts
+++ b/packages/effective-rsc/src/build/dev.ts
@@ -7,10 +7,11 @@ import {
   Path,
   Ref,
   Schema,
+  Scope,
   ScopedRef,
   Stream,
 } from 'effect';
-import { HttpRouter, HttpServer } from 'effect/unstable/http';
+import { HttpBody, HttpRouter, HttpServer, HttpServerResponse } from 'effect/unstable/http';
 
 import PackageJson from '../../package.json' with { type: 'json' };
 import { DevChannelPath } from '../dev/channel';
@@ -71,9 +72,34 @@ export const acquireDevGeneration = Effect.fnUntraced(function* ({
     ),
   );
 
+  // Close request work before the generation's application services.
+  const generationScope = yield* Effect.scope;
+  const requests = yield* Scope.fork(generationScope, 'parallel');
+  const ownRequest = Effect.withFiber((fiber) => {
+    Fiber.runIn(fiber, requests);
+    return Effect.void;
+  });
+
   return {
     hash: compilation.hash,
-    httpEffect,
+    httpEffect: Effect.gen(function* () {
+      yield* ownRequest;
+      const response = yield* httpEffect;
+      const body = response.body;
+      if (body._tag !== 'Stream') {
+        return response;
+      }
+
+      // Bun consumes the response body on a separate fiber after the handler returns.
+      return HttpServerResponse.setBody(
+        response,
+        HttpBody.stream(
+          Stream.onStart(body.stream, ownRequest),
+          body.contentType,
+          body.contentLength,
+        ),
+      );
+    }),
   };
 });
 
@@ -108,6 +134,7 @@ export const makeDevGenerationStore = Effect.fnUntraced(function* (options: DevG
         yield* ScopedRef.set(
           generation,
           acquireDevGeneration({ ...options, compilation: event }).pipe(
+            Effect.interruptible,
             Effect.map((ready): DevGenerationState => ({
               _tag: 'Ready',
               generation: ready,

--- a/packages/effective-rsc/src/cli.ts
+++ b/packages/effective-rsc/src/cli.ts
@@ -116,6 +116,8 @@ const runDev = Effect.fnUntraced(function* ({
     Effect.provide(
       BunHttpServer.layer({
         development: true,
+        // Explicit dev shutdown interrupts request scopes before releasing their generations.
+        disablePreemptiveShutdown: true,
         hostname,
         idleTimeout: ApplicationIdleTimeoutSeconds,
         maxRequestBodySize: ApplicationMaxRequestBodySizeBytes,

--- a/packages/effective-rsc/tests/build/dev.test.ts
+++ b/packages/effective-rsc/tests/build/dev.test.ts
@@ -1,7 +1,21 @@
+// oxlint-disable effecttsgo/global-fetch-in-effect -- These integration tests exercise Bun's native response body readers and disconnects.
 import * as BunHttpServer from '@effect/platform-bun/BunHttpServer';
 import * as BunServices from '@effect/platform-bun/BunServices';
 import { expect, it } from '@effect/vitest';
-import { Deferred, Effect, Fiber, FileSystem, Layer, Logger, Path, Ref, Stream } from 'effect';
+import {
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  FileSystem,
+  Layer,
+  Logger,
+  Path,
+  Ref,
+  Schedule,
+  Scope,
+  Stream,
+} from 'effect';
 import { TestClock } from 'effect/testing';
 import { HttpServer, HttpServerRequest } from 'effect/unstable/http';
 import { RpcClient, RpcSerialization } from 'effect/unstable/rpc';
@@ -31,7 +45,7 @@ const CompilationDetails = {
 } as const;
 
 const serverBundleSource = (httpLayer: string) => `
-  import { Effect, Layer } from ${JSON.stringify(EffectModuleUrl)};
+  import { Effect, FileSystem, Layer, Stream } from ${JSON.stringify(EffectModuleUrl)};
   import { HttpRouter, HttpServerResponse } from ${JSON.stringify(HttpModuleUrl)};
 
   export default {
@@ -79,6 +93,8 @@ it.effect('acquires a complete development generation before returning it', () =
         HttpServerRequest.HttpServerRequest,
         HttpServerRequest.fromWeb(new Request('http://localhost/ready')),
       ),
+      Effect.forkChild,
+      Effect.flatMap(Fiber.join),
     );
     expect(response.status).toBe(200);
 
@@ -129,6 +145,8 @@ it.effect('waits for the current compilation outcome before dispatching', () =>
           HttpServerRequest.HttpServerRequest,
           HttpServerRequest.fromWeb(new Request(`http://localhost${pathname}`)),
         ),
+        Effect.forkChild,
+        Effect.flatMap(Fiber.join),
       );
 
     yield* store.update({ _tag: 'Building', changedFiles: [] });
@@ -184,6 +202,195 @@ it.effect('waits for the current compilation outcome before dispatching', () =>
     });
     const recoveredResponse = yield* Fiber.join(recoveredRequest);
     expect(recoveredResponse.status).toBe(204);
+  }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
+);
+
+const streamServerBundleSource = (closedPath: string) =>
+  serverBundleSource(`Layer.mergeAll(
+    HttpRouter.add('GET', '/stream', Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      yield* Effect.addFinalizer(() => fs.writeFileString(${JSON.stringify(closedPath + '.request')}, 'request/').pipe(Effect.orDie));
+      return HttpServerResponse.stream(
+        Stream.make(new TextEncoder().encode('first')).pipe(
+          Stream.concat(Stream.fromEffect(Effect.sleep('1 second').pipe(Effect.as(new TextEncoder().encode('last'))))),
+          Stream.onExit(() => fs.writeFileString(${JSON.stringify(closedPath + '.body')}, 'body/').pipe(Effect.orDie))
+        )
+      );
+    })),
+    HttpRouter.add('GET', '/pending', Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      yield* Effect.addFinalizer(() => fs.writeFileString(${JSON.stringify(closedPath + '.pending')}, 'pending').pipe(Effect.orDie));
+      yield* fs.writeFileString(${JSON.stringify(closedPath + '.started')}, 'started');
+      return yield* Effect.never;
+    })),
+    Layer.effectDiscard(Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      yield* Effect.addFinalizer(() => Effect.gen(function* () {
+        const body = yield* fs.readFileString(${JSON.stringify(closedPath + '.body')});
+        const request = yield* fs.readFileString(${JSON.stringify(closedPath + '.request')});
+        const pending = yield* fs.readFileString(${JSON.stringify(closedPath + '.pending')});
+        yield* fs.writeFileString(${JSON.stringify(closedPath)}, body + request + pending);
+      }).pipe(Effect.orDie));
+    }))
+  )`);
+
+const replacementScenario = (completion: 'Eof' | 'Disconnect' | 'Rebuild' | 'Shutdown') =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const directory = yield* fileSystem.makeTempDirectoryScoped({
+      prefix: 'ersc-dev-replacement-',
+    });
+    const closedPath = path.join(directory, 'closed');
+    yield* fileSystem.writeFileString(
+      path.join(directory, 'stream.js'),
+      streamServerBundleSource(closedPath),
+    );
+    yield* fileSystem.writeFileString(
+      path.join(directory, 'next.js'),
+      serverBundleSource("HttpRouter.add('GET', '/stream', HttpServerResponse.text('next'))"),
+    );
+    yield* fileSystem.writeFileString(
+      path.join(directory, 'failed.js'),
+      serverBundleSource("Layer.effectDiscard(Effect.fail('startup failed'))"),
+    );
+    const scope = yield* Effect.scope;
+    const generationScope = yield* Scope.fork(scope, 'sequential');
+    const store = yield* makeDevGenerationStore({
+      hostname: 'localhost',
+      port: 18193,
+      root: directory,
+    }).pipe(Scope.provide(generationScope));
+    const compile = (filename: string) =>
+      store.update({
+        _tag: 'Compiled',
+        ...CompilationDetails,
+        hash: filename,
+        serverBundle: { filename, outputPath: directory },
+      });
+    yield* compile('stream.js');
+    const server = yield* HttpServer.HttpServer;
+    const serving = yield* launchDevApplication({
+      closeDevChannel: Effect.void,
+      httpEffect: store.httpEffect,
+      watch: Effect.never,
+    }).pipe(Effect.forkScoped({ startImmediately: true }));
+    const url = HttpServer.formatAddress(server.address);
+    const response = yield* Effect.promise(() => fetch(`${url}/stream`));
+    const reader = response.body!.getReader();
+    const first = yield* Effect.promise(() => reader.read());
+    expect(new TextDecoder().decode(first.value)).toBe('first');
+    yield* Effect.promise((signal) => fetch(`${url}/pending`, { signal })).pipe(
+      Effect.forkScoped({ startImmediately: true }),
+    );
+    yield* fileSystem
+      .exists(closedPath + '.started')
+      .pipe(
+        Effect.repeat({ while: (exists) => !exists, schedule: Schedule.spaced('10 millis') }),
+        Effect.timeout('1 second'),
+        TestClock.withLive,
+      );
+
+    yield* store.update({ _tag: 'Building', changedFiles: [] });
+    yield* compile('failed.js').pipe(Effect.flip);
+    const closedAfterFailure = yield* fileSystem.exists(closedPath);
+    const pendingClosedAfterFailure = yield* fileSystem.exists(closedPath + '.pending');
+    const bodyClosedAfterFailure = yield* fileSystem.exists(closedPath + '.body');
+    expect(closedAfterFailure).toBe(false);
+    expect(pendingClosedAfterFailure).toBe(false);
+    expect(bodyClosedAfterFailure).toBe(false);
+
+    switch (completion) {
+      case 'Eof': {
+        yield* TestClock.adjust('1 second');
+        const last = yield* Effect.promise(() => reader.read());
+        expect(new TextDecoder().decode(last.value)).toBe('last');
+        const eof = yield* Effect.promise(() => reader.read());
+        expect(eof.done).toBe(true);
+        break;
+      }
+      case 'Disconnect':
+        yield* Effect.promise(() => reader.cancel());
+        break;
+      case 'Rebuild':
+      case 'Shutdown':
+        break;
+    }
+
+    if (completion === 'Shutdown') {
+      yield* Fiber.interrupt(serving);
+      yield* Scope.close(generationScope, Exit.void);
+    } else {
+      yield* store.update({ _tag: 'Building', changedFiles: [] });
+      yield* compile('next.js');
+      const next = yield* Effect.promise(() =>
+        fetch(`${url}/stream`).then((response) => response.text()),
+      );
+      expect(next).toBe('next');
+    }
+    // The generation finalizer reads these markers: disposal fails if request cleanup ran late.
+    const cleanupOrder = yield* fileSystem.readFileString(closedPath);
+    expect(cleanupOrder).toBe('body/request/pending');
+    if (completion === 'Rebuild' || completion === 'Shutdown') {
+      const result = yield* Effect.promise(() =>
+        reader.read().then(
+          () => 'Completed' as const,
+          () => 'Interrupted' as const,
+        ),
+      );
+      expect(result).toBe('Interrupted');
+    }
+  }).pipe(
+    Effect.provide(
+      BunHttpServer.layer({ hostname: '127.0.0.1', port: 0, disablePreemptiveShutdown: true }),
+    ),
+    Effect.scoped,
+  );
+
+it.effect('cleans up completed streams before disposing the replaced generation', () =>
+  replacementScenario('Eof'),
+);
+it.effect('cleans up disconnected streams before disposing the replaced generation', () =>
+  replacementScenario('Disconnect'),
+);
+it.effect('cancels pending handlers and streams before disposing the replaced generation', () =>
+  replacementScenario('Rebuild'),
+);
+it.effect('cancels pending handlers and streams before disposing the generation on shutdown', () =>
+  replacementScenario('Shutdown'),
+);
+
+it.effect('interrupts a candidate whose application startup never completes', () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const directory = yield* fileSystem.makeTempDirectoryScoped({ prefix: 'ersc-dev-startup-' });
+    yield* fileSystem.writeFileString(
+      path.join(directory, 'stalled.js'),
+      serverBundleSource(
+        "Layer.effectDiscard(Effect.logInfo('startup entered').pipe(Effect.andThen(Effect.never)))",
+      ),
+    );
+    const store = yield* makeDevGenerationStore({
+      hostname: 'localhost',
+      port: 18193,
+      root: directory,
+    });
+    const started = yield* Deferred.make<void>();
+    const StartupLogger = Logger.layer([
+      Logger.make(() => Deferred.doneUnsafe(started, Exit.void)),
+    ]);
+    const starting = yield* store
+      .update({
+        _tag: 'Compiled',
+        ...CompilationDetails,
+        hash: 'stalled',
+        serverBundle: { filename: 'stalled.js', outputPath: directory },
+      })
+      .pipe(Effect.provide(StartupLogger), Effect.forkScoped({ startImmediately: true }));
+    yield* Deferred.await(started);
+    expect(starting.pollUnsafe()).toBeUndefined();
+    yield* Fiber.interrupt(starting).pipe(Effect.timeout('1 second'), TestClock.withLive);
   }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
 );
 
@@ -245,6 +452,8 @@ it.effect('continues watching after a generation fails to start', () =>
         HttpServerRequest.HttpServerRequest,
         HttpServerRequest.fromWeb(new Request('http://localhost/ready')),
       ),
+      Effect.forkChild,
+      Effect.flatMap(Fiber.join),
     );
 
     expect(response.status).toBe(204);


### PR DESCRIPTION
- Cancel active development requests before disposing their application services.
- Add regression tests for request cancellation during application replacement.