### PR TITLE
fix: recover render failures and synchronize development diagnostics

### DIFF
--- a/docs/architecture/build.md
+++ b/docs/architecture/build.md
@@ -52,6 +52,8 @@ services. The channel accepts only WebSocket handshakes whose `Origin` matches t
 
 Development diagnostics start independently of hydration. Current-route refresh initially reloads
 the document; successful client-navigation activation replaces it with streamed RSC refresh.
+The initial successful socket snapshot reconciles when its hash differs from the loaded browser
+bundle.
 
 React Server Components Performance Tracks remain native. Initial hydration uses the document
 timeline origin; navigation and Server Function decoding receive a timestamp captured before HTTP

--- a/docs/architecture/build.md
+++ b/docs/architecture/build.md
@@ -59,6 +59,9 @@ Caught React render errors include their component stack in the development pane
 HMR or explicit navigation can recover the framework error boundary; starting a refresh alone does
 not clear the error. Healthy trees retain their React state, application error boundaries retain
 their own policy, and recovery never replays a Server Function or retries unchanged code on a timer.
+Build diagnostics clear only when the server reports a successful replacement. A successful render
+or a cached history traversal does not clear a compilation failure, and build success alone does
+not clear a runtime failure.
 
 React Server Components Performance Tracks remain native. Initial hydration uses the document
 timeline origin; navigation and Server Function decoding receive a timestamp captured before HTTP

--- a/docs/architecture/build.md
+++ b/docs/architecture/build.md
@@ -41,6 +41,8 @@ code. Successful replacement interrupts the previous generation's pending handle
 streams before disposing its application services. Saving a file can therefore cut off an active
 response; development does not drain old generations or automatically retry Server Functions.
 Failed candidates leave the current generation's existing requests alone.
+Compilation and application startup failures are reported in both the terminal and the development
+panel. A failed candidate never publishes a successful browser update.
 Content-hashed development server bundles and chunks remain available for the development session.
 
 Browser updates use the compiler's HMR protocol; RSC changes refresh the current route through the

--- a/docs/architecture/build.md
+++ b/docs/architecture/build.md
@@ -55,6 +55,11 @@ the document; successful client-navigation activation replaces it with streamed 
 The initial successful socket snapshot reconciles when its hash differs from the loaded browser
 bundle.
 
+Caught React render errors include their component stack in the development panel. Later
+HMR or explicit navigation can recover the framework error boundary; starting a refresh alone does
+not clear the error. Healthy trees retain their React state, application error boundaries retain
+their own policy, and recovery never replays a Server Function or retries unchanged code on a timer.
+
 React Server Components Performance Tracks remain native. Initial hydration uses the document
 timeline origin; navigation and Server Function decoding receive a timestamp captured before HTTP
 execution. Production compilation removes the timing metadata. React Debug Channel transport and

--- a/docs/architecture/lifetimes-and-protocols.md
+++ b/docs/architecture/lifetimes-and-protocols.md
@@ -49,7 +49,9 @@ rules.
   React and Web Streams own boundary recovery or stream termination.
 - Expected request aborts do not log as render failures.
 - Browser hydration uses one framework error boundary so an unexpected render failure does not crash
-  outside React.
+  outside React. A later navigation or HMR publication can recover it without remounting healthy
+  trees. Caught render failures reach development diagnostics; only a successful recovery commit
+  clears them. Application error boundaries retain their own recovery policy.
 
 ## HTTP policy
 

--- a/fixtures/framework-e2e/e2e/development-build-diagnostics.spec.ts
+++ b/fixtures/framework-e2e/e2e/development-build-diagnostics.spec.ts
@@ -1,0 +1,41 @@
+// oxlint-disable effecttsgo/async-function -- Playwright owns this Promise-based test boundary.
+// oxlint-disable effecttsgo/node-builtin-import -- Playwright edits and restores watched fixture source within its test lifetime.
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { expect, test } from '@playwright/test';
+
+import { observeViewTransitions, waitForViewTransition } from './support/view-transitions';
+
+const homePath = new URL('../src/modules/fixture/components/fixture-home.tsx', import.meta.url);
+
+test('keeps build diagnostics after a cached navigation commits', async ({
+  page,
+  request,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'dev', 'This contract exercises the development server.');
+  const original = await readFile(homePath, 'utf8');
+  await observeViewTransitions(page);
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Probe count: 0' }).click();
+  const documentIdentity = await page.evaluate(() => performance.timeOrigin);
+  await page.evaluate(() => navigation.navigate('/catalog/primary').finished);
+  await expect(page.locator('[data-detail-id="primary-suspense"]')).toBeVisible();
+  const panel = page.locator('ersc-dev-panel');
+  try {
+    await writeFile(homePath, `${original}\nexport const broken = ;\n`);
+    await expect(panel.getByRole('heading', { name: 'Build failed' })).toBeVisible();
+    await page.evaluate(() => navigation.back().finished);
+    await waitForViewTransition(page, ['navigation', 'navigation-traverse', 'navigation-backward']);
+    await expect(page).toHaveURL('/');
+    await expect(
+      page.getByRole('button', { name: 'Probe count: 0', includeHidden: true }),
+    ).toHaveCount(1);
+    await expect(panel.getByRole('heading', { name: 'Build failed' })).toBeVisible();
+    expect((await request.get('/')).status()).toBe(500);
+    expect(await page.evaluate(() => performance.timeOrigin)).toBe(documentIdentity);
+  } finally {
+    await writeFile(homePath, original);
+    await expect(panel.getByRole('heading', { name: 'Build failed' })).toHaveCount(0);
+    await expect.poll(async () => (await request.get('/')).status()).toBe(200);
+  }
+});

--- a/fixtures/framework-e2e/e2e/development-recovery.spec.ts
+++ b/fixtures/framework-e2e/e2e/development-recovery.spec.ts
@@ -1,0 +1,80 @@
+// oxlint-disable effecttsgo/async-function -- Playwright owns this Promise-based test boundary.
+// oxlint-disable effecttsgo/node-builtin-import -- Playwright edits and restores watched fixture source within its test lifetime.
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { expect, test } from '@playwright/test';
+
+const probePath = new URL('../src/modules/fixture/components/runtime-probe.tsx', import.meta.url);
+const homePath = new URL('../src/modules/fixture/components/fixture-home.tsx', import.meta.url);
+
+test.beforeEach(() => {
+  test.skip(test.info().project.name !== 'dev', 'These contracts exercise the development server.');
+});
+
+test('recovers caught React errors on explicit navigation without a document reload', async ({
+  page,
+}) => {
+  await page.goto('/');
+  const documentIdentity = await page.evaluate(() => performance.timeOrigin);
+  await page.getByRole('button', { name: 'Fail React render' }).click();
+  const panel = page.locator('ersc-dev-panel');
+  await expect(panel).toContainText('Fixture React render failure');
+  await expect(panel).toContainText('React component stack');
+  await panel.getByRole('button', { name: 'Close development panel' }).click();
+  await page.evaluate(() => navigation.navigate('/catalog/primary').finished);
+  await expect(page.getByRole('navigation', { name: 'Fixture catalog' })).toBeVisible();
+  await expect(panel.getByRole('heading', { name: 'Runtime failures' })).toHaveCount(0);
+  expect(await page.evaluate(() => performance.timeOrigin)).toBe(documentIdentity);
+});
+
+test('refreshes RSC through a real React commit and preserves healthy client state', async ({
+  page,
+}) => {
+  const original = await readFile(homePath, 'utf8');
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Probe count: 0' }).click();
+  const documentIdentity = await page.evaluate(() => performance.timeOrigin);
+  try {
+    await writeFile(
+      homePath,
+      original.replace('RuntimeProbe />', 'RuntimeProbe /><p>RSC rebuild committed</p>'),
+    );
+    await expect(page.getByText('RSC rebuild committed', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Probe count: 1' })).toBeVisible();
+    expect(await page.evaluate(() => performance.timeOrigin)).toBe(documentIdentity);
+  } finally {
+    await writeFile(homePath, original);
+    await expect(page.getByText('RSC rebuild committed', { exact: true })).toHaveCount(0);
+  }
+});
+
+test('keeps render diagnostics until corrected HMR actually recovers', async ({ page }) => {
+  const original = await readFile(probePath, 'utf8');
+  await page.goto('/');
+  const documentIdentity = await page.evaluate(() => performance.timeOrigin);
+  const panel = page.locator('ersc-dev-panel');
+  try {
+    await page.getByRole('button', { name: 'Fail React render' }).click();
+    await expect(panel).toContainText('Fixture React render failure');
+    await writeFile(
+      probePath,
+      original
+        .replace(
+          "if (phase === 'Failed')",
+          "if (phase === 'Failed' || typeof window !== 'undefined')",
+        )
+        .replace('Fixture React render failure', 'Replacement still fails'),
+    );
+    await expect(panel).toContainText('Replacement still fails');
+    await writeFile(
+      probePath,
+      original.replace('Runtime probe original', 'Runtime probe recovered'),
+    );
+    await expect(page.getByText('Runtime probe recovered', { exact: true })).toBeVisible();
+    await expect(panel.getByRole('heading', { name: 'Runtime failures' })).toHaveCount(0);
+    expect(await page.evaluate(() => performance.timeOrigin)).toBe(documentIdentity);
+  } finally {
+    await writeFile(probePath, original);
+    await expect(page.getByText('Runtime probe original', { exact: true })).toBeVisible();
+  }
+});

--- a/fixtures/framework-e2e/e2e/development-snapshot.spec.ts
+++ b/fixtures/framework-e2e/e2e/development-snapshot.spec.ts
@@ -1,0 +1,45 @@
+// oxlint-disable effecttsgo/async-function -- Playwright owns this Promise-based test boundary.
+// oxlint-disable effecttsgo/node-builtin-import -- Playwright edits and restores watched fixture source within its test lifetime.
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { expect, test } from '@playwright/test';
+
+const probePath = new URL('../src/modules/fixture/components/runtime-probe.tsx', import.meta.url);
+
+test.beforeEach(() => {
+  test.skip(test.info().project.name !== 'dev', 'This contract exercises the development server.');
+});
+
+test('reconciles a newer initial socket snapshot with the loaded browser bundle', async ({
+  page,
+  request,
+}) => {
+  const original = await readFile(probePath, 'utf8');
+  const subscribe = Promise.withResolvers<void>();
+  await page.routeWebSocket('**/_ersc/dev', (socket) => {
+    const server = socket.connectToServer();
+    socket.onMessage((message) => {
+      void subscribe.promise.then(() => server.send(message));
+    });
+  });
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Probe count: 0' }).click();
+  const documentIdentity = await page.evaluate(() => performance.timeOrigin);
+  try {
+    await writeFile(
+      probePath,
+      original.replace('Runtime probe original', 'Runtime probe snapshot'),
+    );
+    await expect
+      .poll(async () => (await request.get('/')).text())
+      .toContain('Runtime probe snapshot');
+    subscribe.resolve();
+    await expect(page.getByText('Runtime probe snapshot', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Probe count: 1' })).toBeVisible();
+    expect(await page.evaluate(() => performance.timeOrigin)).toBe(documentIdentity);
+  } finally {
+    subscribe.resolve();
+    await writeFile(probePath, original);
+    await expect(page.getByText('Runtime probe original', { exact: true })).toBeVisible();
+  }
+});

--- a/fixtures/framework-e2e/e2e/development-startup-diagnostics.spec.ts
+++ b/fixtures/framework-e2e/e2e/development-startup-diagnostics.spec.ts
@@ -1,0 +1,38 @@
+// oxlint-disable effecttsgo/async-function -- Playwright owns this Promise-based test boundary.
+// oxlint-disable effecttsgo/node-builtin-import -- Playwright edits and restores watched fixture source within its test lifetime.
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { expect, test } from '@playwright/test';
+
+const applicationPath = new URL('../src/application.tsx', import.meta.url);
+
+test('reports application startup failure and clears it after successful replacement', async ({
+  page,
+  request,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'dev', 'This contract exercises the development server.');
+  const original = await readFile(applicationPath, 'utf8');
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Probe count: 0' }).click();
+  const documentIdentity = await page.evaluate(() => performance.timeOrigin);
+  const panel = page.locator('ersc-dev-panel');
+  try {
+    await writeFile(
+      applicationPath,
+      original
+        .replace("import { Layer } from 'effect';", "import { Effect, Layer } from 'effect';")
+        .replace(
+          'Layer.mergeAll(SelectionHttpLayer, PublicHttpLayer)',
+          'Layer.mergeAll(SelectionHttpLayer, PublicHttpLayer, Layer.effectDiscard(Effect.fail(new Error("Fixture startup failed"))))',
+        ),
+    );
+    await expect.poll(async () => (await request.get('/')).status()).toBe(500);
+    await expect(panel.getByRole('heading', { name: 'Build failed' })).toBeVisible();
+    await expect(panel).toContainText('Fixture startup failed');
+    expect(await page.evaluate(() => performance.timeOrigin)).toBe(documentIdentity);
+  } finally {
+    await writeFile(applicationPath, original);
+    await expect.poll(async () => (await request.get('/')).status()).toBe(200);
+    await expect(panel.getByRole('heading', { name: 'Build failed' })).toHaveCount(0);
+  }
+});

--- a/fixtures/framework-e2e/src/modules/fixture/components/fixture-home.tsx
+++ b/fixtures/framework-e2e/src/modules/fixture/components/fixture-home.tsx
@@ -9,6 +9,8 @@ import { cn } from '@/lib/utils';
 import type { FixtureMetadata, ObservedQuery } from '@/modules/fixture/model';
 import { FixtureService } from '@/modules/fixture/service';
 
+import RuntimeProbe from './runtime-probe';
+
 type FixtureHomeProps = {
   readonly fixture: ObservedQuery<FixtureMetadata>;
 };
@@ -51,6 +53,7 @@ function FixtureHomeView({ fixture }: FixtureHomeProps) {
         </div>
       </header>
 
+      <RuntimeProbe />
       <section className='grid gap-4 py-9 sm:grid-cols-2' aria-label='Fixture route groups'>
         {groups.map((group) => (
           <Card key={group.href}>

--- a/fixtures/framework-e2e/src/modules/fixture/components/runtime-probe.tsx
+++ b/fixtures/framework-e2e/src/modules/fixture/components/runtime-probe.tsx
@@ -4,12 +4,20 @@ import { useState } from 'react';
 
 export default function RuntimeProbe() {
   const [count, setCount] = useState(0);
+  const [phase, setPhase] = useState<'Ready' | 'Failed'>('Ready');
+
+  if (phase === 'Failed') {
+    throw new Error('Fixture React render failure');
+  }
 
   return (
     <section aria-label='Runtime recovery probe'>
       <p>Runtime probe original</p>
       <button onClick={() => setCount((value) => value + 1)} type='button'>
         Probe count: {count}
+      </button>
+      <button onClick={() => setPhase('Failed')} type='button'>
+        Fail React render
       </button>
     </section>
   );

--- a/fixtures/framework-e2e/src/modules/fixture/components/runtime-probe.tsx
+++ b/fixtures/framework-e2e/src/modules/fixture/components/runtime-probe.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function RuntimeProbe() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <section aria-label='Runtime recovery probe'>
+      <p>Runtime probe original</p>
+      <button onClick={() => setCount((value) => value + 1)} type='button'>
+        Probe count: {count}
+      </button>
+    </section>
+  );
+}

--- a/packages/effective-rsc/src/build/dev.ts
+++ b/packages/effective-rsc/src/build/dev.ts
@@ -1,4 +1,5 @@
 import {
+  Cause,
   Deferred,
   Effect,
   Fiber,
@@ -224,7 +225,11 @@ export const makeDevApplication = Effect.fnUntraced(function* ({
 
             return Effect.logInfo(`${Terminal.green('✓')} Ready${duration}${details}`);
           }),
-          Effect.catch((error) => Effect.logError(error)),
+          Effect.catch((error) =>
+            channel
+              .publishBuildFailure(Cause.pretty(Cause.fail(error)))
+              .pipe(Effect.andThen(Effect.logError(error))),
+          ),
         );
       }
     }

--- a/packages/effective-rsc/src/client/application.ts
+++ b/packages/effective-rsc/src/client/application.ts
@@ -4,6 +4,7 @@ import { Effect, Layer } from 'effect';
 
 import { checkBrowserCapabilities } from './browser-capabilities';
 import { BrowserEffectRunner } from './browser-effect-runner';
+import { BrowserRenderStatus } from './browser-render-status';
 import { BrowserRenderer } from './browser-renderer';
 import { showBrowserFailure } from './browser-screen';
 import { installCallServer } from './call-server';
@@ -18,6 +19,7 @@ import { installRouteRefresh, RouteRefresher } from './route-refresh';
 const BrowserServicesLayer = Layer.mergeAll(
   BrowserEffectRunner.layer,
   BrowserRenderer.layer,
+  BrowserRenderStatus.layer,
   FlightClient.layer,
   NavigationApi.layer,
 ).pipe(Layer.provide(InitialFlightStream.layer));

--- a/packages/effective-rsc/src/client/browser-render-status.ts
+++ b/packages/effective-rsc/src/client/browser-render-status.ts
@@ -1,0 +1,22 @@
+import { Context, Effect, Layer, SubscriptionRef } from 'effect';
+
+type RenderStatus =
+  | { readonly _tag: 'Waiting' }
+  | { readonly _tag: 'Rendered' }
+  | { readonly _tag: 'Failed'; readonly error: unknown; readonly componentStack: string | null };
+
+// Replay the latest status: diagnostics may start after hydration has already failed.
+export class BrowserRenderStatus extends Context.Service<BrowserRenderStatus>()(
+  'ersc/client/BrowserRenderStatus',
+  {
+    make: SubscriptionRef.make<RenderStatus>({ _tag: 'Waiting' }).pipe(
+      Effect.map((status) => ({
+        changes: SubscriptionRef.changes(status),
+        get: SubscriptionRef.get(status),
+        report: (value: RenderStatus) => SubscriptionRef.set(status, value),
+      })),
+    ),
+  },
+) {
+  static readonly layer = Layer.effect(this, this.make);
+}

--- a/packages/effective-rsc/src/client/react-dom-renderer.tsx
+++ b/packages/effective-rsc/src/client/react-dom-renderer.tsx
@@ -11,6 +11,7 @@ import { hydrateRoot } from 'react-dom/client';
 
 import type { FlightPayload } from '../rsc/flight';
 import { BrowserEffectRunner } from './browser-effect-runner';
+import { BrowserRenderStatus } from './browser-render-status';
 import { type BrowserRender, BrowserRenderer } from './browser-renderer';
 import { BrowserFailureScreen } from './browser-screen';
 import { RouteTree } from './route-tree';
@@ -20,21 +21,51 @@ export class ReactDOMHydrationError extends Schema.TaggedError<ReactDOMHydration
   { cause: Schema.Defect() },
 ) {}
 
-type BrowserErrorBoundaryState = { readonly _tag: 'Ready' } | { readonly _tag: 'Failed' };
+type BrowserErrorBoundaryState =
+  | { readonly _tag: 'Uninitialized' }
+  | { readonly _tag: 'Ready'; readonly render: BrowserRender }
+  | { readonly _tag: 'Failed'; readonly render: BrowserRender };
 type BrowserErrorBoundaryProps = {
   readonly children: ReactNode;
   readonly onError: (error: unknown, info: ErrorInfo) => void;
+  readonly onRendered: () => void;
+  readonly render: BrowserRender;
 };
 
 class BrowserErrorBoundary extends Component<BrowserErrorBoundaryProps, BrowserErrorBoundaryState> {
-  override readonly state: BrowserErrorBoundaryState = { _tag: 'Ready' };
+  override readonly state: BrowserErrorBoundaryState = { _tag: 'Uninitialized' };
 
-  static getDerivedStateFromError(): BrowserErrorBoundaryState {
-    return { _tag: 'Failed' };
+  static getDerivedStateFromError() {
+    return { _tag: 'Failed' } as const;
+  }
+
+  static getDerivedStateFromProps(
+    props: BrowserErrorBoundaryProps,
+    state: BrowserErrorBoundaryState,
+  ): BrowserErrorBoundaryState | null {
+    if (state._tag !== 'Uninitialized' && props.render === state.render) {
+      return null;
+    }
+    // Discard acknowledges a cancelled candidate, not a request to retry the failed tree.
+    return state._tag === 'Failed' && props.render._tag === 'Discard'
+      ? { _tag: 'Failed', render: props.render }
+      : { _tag: 'Ready', render: props.render };
   }
 
   override componentDidCatch(error: unknown, info: ErrorInfo) {
     this.props.onError(error, info);
+  }
+
+  override componentDidMount() {
+    if (this.state._tag === 'Ready') {
+      this.props.onRendered();
+    }
+  }
+
+  override componentDidUpdate() {
+    if (this.state._tag === 'Ready') {
+      this.props.onRendered();
+    }
   }
 
   override render() {
@@ -52,6 +83,7 @@ export class ReactDOMRenderer extends Context.Service<ReactDOMRenderer>()(
     make: Effect.gen(function* () {
       const browserRenderer = yield* BrowserRenderer;
       const run = yield* BrowserEffectRunner;
+      const renderStatus = yield* BrowserRenderStatus;
 
       const hydrate = Effect.fnUntraced(function* (
         container: Element | Document,
@@ -59,7 +91,20 @@ export class ReactDOMRenderer extends Context.Service<ReactDOMRenderer>()(
       ) {
         const browserRendererReady = Promise.withResolvers<void>();
         const reportError = (error: unknown, info: ErrorInfo) => {
-          void run(Effect.logError('Uncaught client render error.', error, info.componentStack));
+          void run(
+            Effect.gen(function* () {
+              yield* renderStatus.report({
+                _tag: 'Failed',
+                error,
+                componentStack: info.componentStack ?? null,
+              });
+              yield* Effect.logError('Uncaught client render error.', error, info.componentStack);
+            }),
+          );
+        };
+
+        const reportRendered = () => {
+          void run(renderStatus.report({ _tag: 'Rendered' }));
         };
 
         function Root() {
@@ -78,7 +123,7 @@ export class ReactDOMRenderer extends Context.Service<ReactDOMRenderer>()(
           }, [render]);
 
           return (
-            <BrowserErrorBoundary onError={reportError}>
+            <BrowserErrorBoundary onError={reportError} onRendered={reportRendered} render={render}>
               <RouteTree root={render.routeTree} />
             </BrowserErrorBoundary>
           );

--- a/packages/effective-rsc/src/dev/client.ts
+++ b/packages/effective-rsc/src/dev/client.ts
@@ -92,7 +92,7 @@ export const startDevClient = Effect.gen(function* () {
       // Starting a refresh is not evidence that the replacement rendered successfully.
       return;
     }
-    yield* panel.dispatch({ _tag: 'Reconciled' });
+    yield* panel.dispatch({ _tag: 'RuntimeReconciled' });
   });
   yield* renderStatus.changes.pipe(
     Stream.runForEach((status) => {
@@ -100,7 +100,7 @@ export const startDevClient = Effect.gen(function* () {
         case 'Waiting':
           return Effect.void;
         case 'Rendered':
-          return panel.dispatch({ _tag: 'Reconciled' });
+          return panel.dispatch({ _tag: 'RuntimeReconciled' });
         case 'Failed':
           return panel.dispatch({
             _tag: 'RenderFailed',
@@ -119,8 +119,11 @@ export const startDevClient = Effect.gen(function* () {
     const handleUpdate = Effect.fnUntraced(function* (phase: DevUpdatePhase, message: DevUpdate) {
       if (message._tag === 'BuildFailed') {
         yield* panel.dispatch(message);
-      } else if (phase === 'Live' || message.clientHash !== import.meta.rspackHash) {
-        yield* handleHotUpdate(message);
+      } else {
+        yield* panel.dispatch({ _tag: 'BuildSucceeded' });
+        if (phase === 'Live' || message.clientHash !== import.meta.rspackHash) {
+          yield* handleHotUpdate(message);
+        }
       }
 
       return 'Live' as const;

--- a/packages/effective-rsc/src/dev/client.ts
+++ b/packages/effective-rsc/src/dev/client.ts
@@ -98,7 +98,7 @@ export const startDevClient = Effect.gen(function* () {
     const handleUpdate = Effect.fnUntraced(function* (phase: DevUpdatePhase, message: DevUpdate) {
       if (message._tag === 'BuildFailed') {
         yield* panel.dispatch(message);
-      } else if (phase === 'Live') {
+      } else if (phase === 'Live' || message.clientHash !== import.meta.rspackHash) {
         yield* handleHotUpdate(message);
       }
 

--- a/packages/effective-rsc/src/dev/client.ts
+++ b/packages/effective-rsc/src/dev/client.ts
@@ -2,11 +2,12 @@ import * as BrowserSocket from '@effect/platform-browser/BrowserSocket';
 import { Effect, Layer, Ref, Semaphore, Stream } from 'effect';
 import { RpcClient, RpcSerialization } from 'effect/unstable/rpc';
 
+import { BrowserRenderStatus } from '../client/browser-render-status';
 import { RouteRefresher } from '../client/route-refresh';
 import { DevChannelPath, DevRpcs, type DevUpdate } from './channel';
 import { decideHotUpdate, type HotUpdateCheck, type PendingDevUpdate } from './hmr-update';
 import { makeDevPanel } from './panel';
-import { reportBrowserFailures } from './runtime-failure';
+import { fromRenderError, reportBrowserFailures } from './runtime-failure';
 
 const socketProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
 const socketUrl = `${socketProtocol}//${location.host}${DevChannelPath}`;
@@ -71,6 +72,7 @@ const settlePendingUpdate = Effect.fnUntraced(function* (pendingUpdate: Ref.Ref<
 
 export const startDevClient = Effect.gen(function* () {
   const routeRefresher = yield* RouteRefresher;
+  const renderStatus = yield* BrowserRenderStatus;
   const panel = yield* makeDevPanel;
   const pendingUpdate = yield* Ref.make<PendingDevUpdate>({
     acknowledgedClientHash: import.meta.rspackHash,
@@ -84,11 +86,30 @@ export const startDevClient = Effect.gen(function* () {
     if (action === 'Reloading') {
       return;
     }
-    if (action === 'Refresh') {
+    const status = yield* renderStatus.get;
+    if (action === 'Refresh' || status._tag === 'Failed') {
       yield* routeRefresher.refreshCurrentRoute('hmr-refresh');
+      // Starting a refresh is not evidence that the replacement rendered successfully.
+      return;
     }
     yield* panel.dispatch({ _tag: 'Reconciled' });
   });
+  yield* renderStatus.changes.pipe(
+    Stream.runForEach((status) => {
+      switch (status._tag) {
+        case 'Waiting':
+          return Effect.void;
+        case 'Rendered':
+          return panel.dispatch({ _tag: 'Reconciled' });
+        case 'Failed':
+          return panel.dispatch({
+            _tag: 'RenderFailed',
+            failure: fromRenderError(status.error, status.componentStack),
+          });
+      }
+    }),
+    Effect.forkScoped,
+  );
   yield* reportBrowserFailures((failure) =>
     panel.dispatch({ _tag: 'RuntimeFailed', failure }),
   ).pipe(Effect.forkScoped);

--- a/packages/effective-rsc/src/dev/panel.tsx
+++ b/packages/effective-rsc/src/dev/panel.tsx
@@ -25,7 +25,8 @@ export type DevPanelEvent =
   | { readonly _tag: 'BuildFailed'; readonly diagnostics: string }
   | { readonly _tag: 'RuntimeFailed'; readonly failure: DevRuntimeFailure }
   | { readonly _tag: 'RenderFailed'; readonly failure: DevRuntimeFailure }
-  | { readonly _tag: 'Reconciled' }
+  | { readonly _tag: 'BuildSucceeded' }
+  | { readonly _tag: 'RuntimeReconciled' }
   | { readonly _tag: 'Opened' }
   | { readonly _tag: 'Dismissed' };
 
@@ -50,6 +51,9 @@ const appendRuntimeFailure = (
 export const applyDevPanelEvent = (state: DevPanelState, event: DevPanelEvent): DevPanelState => {
   switch (event._tag) {
     case 'RenderFailed':
+      if (state._tag !== 'Inactive' && state.content._tag === 'BuildFailed') {
+        return state;
+      }
       return {
         _tag: 'Visible',
         content: { _tag: 'RuntimeFailed', failures: [event.failure] },
@@ -85,8 +89,14 @@ export const applyDevPanelEvent = (state: DevPanelState, event: DevPanelEvent): 
           }
       }
     }
-    case 'Reconciled':
-      return InitialDevPanelState;
+    case 'BuildSucceeded':
+      return state._tag !== 'Inactive' && state.content._tag === 'BuildFailed'
+        ? InitialDevPanelState
+        : state;
+    case 'RuntimeReconciled':
+      return state._tag !== 'Inactive' && state.content._tag === 'RuntimeFailed'
+        ? InitialDevPanelState
+        : state;
     case 'Opened':
       return state._tag === 'Dismissed' ? { _tag: 'Visible', content: state.content } : state;
     case 'Dismissed':

--- a/packages/effective-rsc/src/dev/panel.tsx
+++ b/packages/effective-rsc/src/dev/panel.tsx
@@ -205,7 +205,7 @@ function DevPanelContent({ state }: { readonly state: DevPanelState }) {
             {isBuildFailure ? (
               <section className='build-failure'>
                 <div className='section-heading'>
-                  <span>Compiler output</span>
+                  <span>Build diagnostics</span>
                   <span>Fix the error and save to retry</span>
                 </div>
                 <pre className='build-output'>{state.content.diagnostics}</pre>

--- a/packages/effective-rsc/src/dev/panel.tsx
+++ b/packages/effective-rsc/src/dev/panel.tsx
@@ -24,6 +24,7 @@ export type DevPanelState =
 export type DevPanelEvent =
   | { readonly _tag: 'BuildFailed'; readonly diagnostics: string }
   | { readonly _tag: 'RuntimeFailed'; readonly failure: DevRuntimeFailure }
+  | { readonly _tag: 'RenderFailed'; readonly failure: DevRuntimeFailure }
   | { readonly _tag: 'Reconciled' }
   | { readonly _tag: 'Opened' }
   | { readonly _tag: 'Dismissed' };
@@ -48,6 +49,11 @@ const appendRuntimeFailure = (
 
 export const applyDevPanelEvent = (state: DevPanelState, event: DevPanelEvent): DevPanelState => {
   switch (event._tag) {
+    case 'RenderFailed':
+      return {
+        _tag: 'Visible',
+        content: { _tag: 'RuntimeFailed', failures: [event.failure] },
+      };
     case 'BuildFailed':
       return {
         _tag: 'Visible',

--- a/packages/effective-rsc/src/dev/runtime-failure.ts
+++ b/packages/effective-rsc/src/dev/runtime-failure.ts
@@ -41,6 +41,14 @@ export const fromUnhandledRejection = (
 ): DevRuntimeFailure =>
   fromUnknown('UnhandledRejection', event.reason, 'Unhandled promise rejection.');
 
+export const fromRenderError = (
+  error: unknown,
+  componentStack: string | null,
+): DevRuntimeFailure => ({
+  ...fromUnknown('RuntimeError', error, 'Unknown React render error.'),
+  ...(componentStack === null ? {} : { componentStack }),
+});
+
 export const reportBrowserFailures = Effect.fnUntraced(function* (
   report: (failure: DevRuntimeFailure) => Effect.Effect<void>,
 ) {

--- a/packages/effective-rsc/tests/client/dev-panel.test.ts
+++ b/packages/effective-rsc/tests/client/dev-panel.test.ts
@@ -88,7 +88,7 @@ describe('development panel state', () => {
   it('clears failures only after reconciliation', () => {
     const failed = apply({ _tag: 'RuntimeFailed', failure: runtimeFailure('render failed') });
 
-    expect(applyDevPanelEvent(failed, { _tag: 'Reconciled' })).toEqual({
+    expect(applyDevPanelEvent(failed, { _tag: 'RuntimeReconciled' })).toEqual({
       _tag: 'Inactive',
     });
   });
@@ -96,11 +96,38 @@ describe('development panel state', () => {
   it('replaces build diagnostics when the replacement reaches React but still fails', () => {
     const state = apply(
       { _tag: 'BuildFailed', diagnostics: 'Compilation failed' },
+      { _tag: 'BuildSucceeded' },
       { _tag: 'RenderFailed', failure: runtimeFailure('replacement still fails') },
     );
     expect(state).toEqual({
       _tag: 'Visible',
       content: { _tag: 'RuntimeFailed', failures: [runtimeFailure('replacement still fails')] },
     });
+  });
+
+  it('keeps visible and dismissed build failures until the build succeeds', () => {
+    const failed = apply({ _tag: 'BuildFailed', diagnostics: 'Compilation failed' });
+    const dismissed = applyDevPanelEvent(failed, { _tag: 'Dismissed' });
+    for (const state of [failed, dismissed]) {
+      expect(applyDevPanelEvent(state, { _tag: 'RuntimeReconciled' })).toBe(state);
+      expect(
+        applyDevPanelEvent(state, {
+          _tag: 'RenderFailed',
+          failure: runtimeFailure('old tree failed'),
+        }),
+      ).toBe(state);
+      expect(applyDevPanelEvent(state, { _tag: 'BuildSucceeded' })).toEqual({ _tag: 'Inactive' });
+    }
+  });
+
+  it('does not treat build success as runtime recovery', () => {
+    const failed = apply({ _tag: 'RenderFailed', failure: runtimeFailure('render failed') });
+    const dismissed = applyDevPanelEvent(failed, { _tag: 'Dismissed' });
+    for (const state of [failed, dismissed]) {
+      expect(applyDevPanelEvent(state, { _tag: 'BuildSucceeded' })).toBe(state);
+      expect(applyDevPanelEvent(state, { _tag: 'RuntimeReconciled' })).toEqual({
+        _tag: 'Inactive',
+      });
+    }
   });
 });

--- a/packages/effective-rsc/tests/client/dev-panel.test.ts
+++ b/packages/effective-rsc/tests/client/dev-panel.test.ts
@@ -92,4 +92,15 @@ describe('development panel state', () => {
       _tag: 'Inactive',
     });
   });
+
+  it('replaces build diagnostics when the replacement reaches React but still fails', () => {
+    const state = apply(
+      { _tag: 'BuildFailed', diagnostics: 'Compilation failed' },
+      { _tag: 'RenderFailed', failure: runtimeFailure('replacement still fails') },
+    );
+    expect(state).toEqual({
+      _tag: 'Visible',
+      content: { _tag: 'RuntimeFailed', failures: [runtimeFailure('replacement still fails')] },
+    });
+  });
 });


### PR DESCRIPTION
- Recover render errors through navigation and HMR.
- Detect when the browser has loaded an older development build.
- Clear build and runtime errors independently.
- Show application startup failures in the dev panel.