### PR TITLE
feat: support positional Server Function inputs

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -71,6 +71,7 @@ entry; read Git history for what it said.
 | D-065 | Let hydrated Server Functions execute concurrently; only the latest applicable response may render its embedded tree, while other completions refresh the current route and newer response trees interrupt older refreshes.                                       |
 | D-066 | Finish native Navigation at first UI commit. The client router retains Flight until EOF or render retirement, preserves visible UI while successors prepare, discards precommit renders before release, and uses React errors without history rollback.           |
 | D-067 | Keep React `<ViewTransition>` boundaries and styles application-owned. At publication, tag routes with additive kind, direction, and UA visual-transition types, and tag Server Function and HMR refreshes with dedicated types.                                  |
+| D-068 | Let ServerFn input be one Schema for one argument or a readonly schema list for positional arguments, including previous state and FormData for native useActionState. A Tuple or Array Schema remains a single argument. Resolves OQ-008.                        |
 
 ## Deferred
 

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -37,24 +37,6 @@ IDs are append-only and never reused, including after a question is resolved.
 - **Resolution:** Unresolved.
 - **Status:** Open.
 
-### OQ-008 — Multi-argument Server Function input
-
-- **Question:** How should ERSC model React actions that receive both previous state and submitted
-  input?
-- **Why:** `ERSC.ServerFn.make` currently models one encoded input. Direct form actions fit that
-  contract, while `useActionState` payload actions receive `(previousState, payload)`.
-- **Affected:** Server Function Schema authoring, `useActionState`, progressive enhancement, and
-  client reference typing.
-- **Evidence:** `Schema.fromFormData(...)` provides a sound one-argument `FormData` contract but
-  cannot describe React's two-argument action signature without loosening inference or adding an
-  explicit API shape. The event-platform checkout needs decoded `FormData` plus a typed result for
-  inline payment, inventory, and idempotency feedback; it currently calls the one-input Server
-  Function from a client transition and stores that result locally instead of using
-  `useActionState`.
-- **Related:** D-009, D-036, D-040, OQ-006.
-- **Resolution:** Unresolved.
-- **Status:** Open.
-
 ## Deferred
 
 ### OQ-002 — Suspensing Loading diagnostics

--- a/docs/architecture/authoring.md
+++ b/docs/architecture/authoring.md
@@ -37,6 +37,13 @@ Component Effects remain attached to the HTTP request.
 Server Function handlers execute directly in the HTTP request fiber. If a Server Function refreshes
 the current route, the refreshed Page, Layout, and Component Effects use the render runtime.
 
+`ServerFn.make` accepts one Schema for a single argument, or a readonly list of Schemas for
+positional arguments. The caller passes each Schema's encoded value and the handler receives each
+decoded value in the same position. An empty list declares no arguments. Array and Tuple Schemas
+remain single-argument inputs. A state Schema followed by a FormData decoder supports native
+`useActionState` actions with `(previousState, payload)` arguments without changing React's
+transport or binding.
+
 ## Routes
 
 `Routes.make` creates immutable scopes. `page(path, page)` adds an Effect HTTP pattern;

--- a/examples/event-platform/e2e/check-in.spec.ts
+++ b/examples/event-platform/e2e/check-in.spec.ts
@@ -13,10 +13,17 @@ test('checks in a credential and reverses the operation', async ({ page }) => {
   await expect(
     page.getByText('Arrived', { exact: true }).locator('..').getByText('0', { exact: true }),
   ).toBeVisible();
+  await page.getByLabel('Ticket code').fill('GTH-MISSING');
+  await page.getByRole('button', { name: 'Check in' }).click();
+  await expect(page.getByText('No ticket matched this credential for the event.')).toBeVisible();
+  await expect(page.getByLabel('Ticket code')).toHaveValue('GTH-MISSING');
+  await expect(page.getByLabel('Ticket code')).toBeFocused();
   await page.getByLabel('Ticket code').fill('GTH-DEMOADA0001');
   await page.getByRole('button', { name: 'Check in' }).click();
 
   await expect(page.getByText('Ada Lovelace is checked in.')).toBeVisible();
+  await expect(page.getByLabel('Ticket code')).toHaveValue('GTH-DEMOADA0001');
+  await expect(page.getByLabel('Ticket code')).toBeFocused();
   await expect(
     page.getByText('Arrived', { exact: true }).locator('..').getByText('1', { exact: true }),
   ).toBeVisible();

--- a/examples/event-platform/e2e/organizer.spec.ts
+++ b/examples/event-platform/e2e/organizer.spec.ts
@@ -45,6 +45,21 @@ test('authors, publishes, discovers, and registers for an event', async ({ page 
   await ticketForm.getByRole('button', { name: 'Add ticket' }).click();
   await expect(page.getByRole('heading', { name: 'Standard admission' })).toBeVisible();
 
+  const authoredTicket = page
+    .locator('form')
+    .filter({ has: page.getByRole('heading', { name: 'Standard admission' }) });
+  await authoredTicket.getByRole('button', { name: 'Hide from sale' }).click();
+  await expect(authoredTicket.getByText('Ticket is hidden.')).toBeVisible();
+  await authoredTicket.getByLabel('Quantity').fill('101');
+  await authoredTicket.getByRole('button', { name: 'Save ticket' }).click();
+  await expect(
+    authoredTicket.getByText('Capacity cannot be lower than allocated, sold, or reserved tickets.'),
+  ).toBeVisible();
+  await expect(authoredTicket.getByLabel('Quantity')).toHaveValue('101');
+  await authoredTicket.getByLabel('Quantity').fill('50');
+  await authoredTicket.getByRole('button', { name: 'Put on sale' }).click();
+  await expect(authoredTicket.getByText('Ticket is on sale.')).toBeVisible();
+
   await page.getByRole('link', { name: 'Manage programme' }).click();
   const roomForm = page
     .locator('form')
@@ -86,6 +101,12 @@ test('authors, publishes, discovers, and registers for an event', async ({ page 
   await expect(authoredSession).toBeVisible();
   await authoredSession.getByRole('button', { name: 'Publish session' }).click();
   await expect(page.getByText('Session published.')).toBeVisible();
+  await authoredSession.getByRole('button', { name: 'Save session' }).click();
+  await expect(authoredSession.getByText('Session saved.')).toBeVisible();
+  await authoredSession.getByRole('button', { name: 'Move to draft' }).click();
+  await expect(authoredSession.getByText('Session moved to draft.')).toBeVisible();
+  await authoredSession.getByRole('button', { name: 'Publish session' }).click();
+  await expect(authoredSession.getByText('Session published.')).toBeVisible();
 
   await page.goto('/organizer');
   const authoredEvent = page
@@ -161,9 +182,17 @@ test('drafts and delivers a targeted attendee announcement', async ({ page }, te
   await page.getByLabel('Subject').fill(subject);
   await page.getByLabel('Audience', { exact: true }).selectOption('not_checked_in');
   await page.getByLabel('Message').fill('Doors open at 08:30. Bring your ticket code.');
+  const announcementId = page
+    .locator('form')
+    .filter({ has: page.getByRole('button', { name: 'Save draft' }) })
+    .locator('input[name="announcementId"]');
+  const draftId = await announcementId.inputValue();
   await page.getByRole('button', { name: 'Save draft' }).click();
 
   await expect(page.getByText('Announcement draft saved.')).toBeVisible();
+  await expect(page.getByLabel('Subject')).toHaveValue('');
+  await expect(page.getByLabel('Message')).toHaveValue('');
+  await expect(announcementId).not.toHaveValue(draftId);
   const announcement = page
     .locator('[data-slot="card"]')
     .filter({ has: page.getByText(subject, { exact: true }) });
@@ -202,9 +231,23 @@ test('refunds an attendee order and returns its inventory', async ({ page }) => 
   await expect(order.getByText('paid', { exact: true })).toBeVisible();
   await order.getByRole('button', { name: 'Refund order' }).click();
   await page.getByLabel('Refund reason').fill('Attendee requested cancellation');
+  const orderIdInput = page.getByRole('alertdialog').locator('input[name="orderId"]');
+  const orderId = await orderIdInput.inputValue();
+  await orderIdInput.evaluate((input: HTMLInputElement) => {
+    input.value = 'missing-order';
+  });
+  await page.getByRole('button', { name: 'Confirm refund' }).click();
+  await expect(page.getByText('That order is unavailable or was already refunded.')).toBeAttached();
+  await expect(page.getByRole('alertdialog')).toBeVisible();
+  await expect(page.getByLabel('Refund reason')).toHaveValue('Attendee requested cancellation');
+  await expect(page.getByRole('button', { name: 'Confirm refund' })).toBeEnabled();
+  await orderIdInput.evaluate((input: HTMLInputElement, value) => {
+    input.value = value;
+  }, orderId);
   await page.getByRole('button', { name: 'Confirm refund' }).click();
 
   await expect(page.getByText('Order refunded and attendee notified.')).toBeVisible();
+  await expect(page.getByRole('alertdialog')).toHaveCount(0);
   await expect(order.getByText('refunded', { exact: true })).toBeVisible();
   await expect(order.getByRole('button', { name: 'Refund order' })).toHaveCount(0);
 
@@ -236,9 +279,27 @@ test('configures and archives a custom registration question', async ({ page }, 
   await page.getByLabel('Help text').fill('Used to tailor the programme.');
   await page.getByLabel('Answer type').selectOption('select');
   await page.getByLabel('Requirement').selectOption('true');
+  const questionId = page
+    .locator('form')
+    .filter({ has: page.getByRole('button', { name: 'Add question' }) })
+    .locator('input[name="questionId"]');
+  const firstQuestionId = await questionId.inputValue();
+  await page.getByLabel('Select options').fill('New to Effect');
+  await page.getByRole('button', { name: 'Add question' }).click();
+  await expect(
+    page.locator('[aria-live="polite"]').filter({
+      hasText: 'Select questions need at least two distinct options.',
+    }),
+  ).toBeVisible();
+  await expect(page.getByLabel('Question', { exact: true })).toHaveValue(question);
+  await expect(page.getByLabel('Select options')).toHaveValue('New to Effect');
+  await expect(questionId).toHaveValue(firstQuestionId);
   await page.getByLabel('Select options').fill('New to Effect\nUsing Effect in production');
   await page.getByRole('button', { name: 'Add question' }).click();
   await expect(page.getByText('Registration question created.')).toBeVisible();
+  await expect(page.getByLabel('Question', { exact: true })).toHaveValue('');
+  await expect(page.getByLabel('Select options')).toHaveValue('');
+  await expect(questionId).not.toHaveValue(firstQuestionId);
 
   const card = page
     .locator('[data-slot="card"]')

--- a/examples/event-platform/e2e/registration.spec.ts
+++ b/examples/event-platform/e2e/registration.spec.ts
@@ -84,6 +84,18 @@ test('joins a sold-out waitlist and receives an organizer update', async ({ page
   const entry = page
     .locator('[data-slot="card"]')
     .filter({ has: page.getByText('Katherine Johnson', { exact: true }) });
+  const entryIdInput = entry.locator('input[name="entryId"]');
+  const entryId = await entryIdInput.inputValue();
+  await entryIdInput.evaluate((input: HTMLInputElement) => {
+    input.value = 'missing-entry';
+  });
+  await entry.getByRole('button', { name: 'Send update' }).click();
+  await expect(
+    entry.getByText('That attendee was already notified or is unavailable.'),
+  ).toBeVisible();
+  await entryIdInput.evaluate((input: HTMLInputElement, value) => {
+    input.value = value;
+  }, entryId);
   await entry.getByRole('button', { name: 'Send update' }).click();
   await expect(page.getByText(`Update sent to ${attendeeEmail}.`)).toBeVisible();
   await expect(entry.getByText('notified', { exact: true })).toBeVisible();

--- a/examples/event-platform/e2e/registration.spec.ts
+++ b/examples/event-platform/e2e/registration.spec.ts
@@ -18,6 +18,21 @@ test('registers an attendee and manages the issued ticket', async ({ page }, tes
   await page.getByLabel('Discount code').fill('community20');
   await page.getByLabel('What is your role?').fill('Platform engineer');
   await page.getByLabel('Dietary preference').selectOption('Vegetarian');
+  await page.getByRole('radio', { name: 'Decline payment' }).check();
+  const checkout = page
+    .locator('form')
+    .filter({ has: page.getByRole('button', { name: 'Complete registration' }) });
+  const attemptKey = checkout.locator('input[name="idempotencyKey"]');
+  const firstAttemptKey = await attemptKey.inputValue();
+  await page.getByRole('button', { name: 'Complete registration' }).click();
+  await expect(
+    page.getByText('The simulated payment was declined. No ticket was issued.'),
+  ).toBeVisible();
+  await expect(page.getByLabel('Name', { exact: true })).toHaveValue(attendeeName);
+  await expect(page.getByLabel('Email', { exact: true })).toHaveValue(attendeeEmail);
+  await expect(page.getByLabel('What is your role?')).toHaveValue('Platform engineer');
+  await expect(attemptKey).not.toHaveValue(firstAttemptKey);
+  await page.getByRole('radio', { name: 'Approve payment' }).check();
   await page.getByRole('button', { name: 'Complete registration' }).click();
 
   await expect(page.getByRole('heading', { name: 'You’re registered' })).toBeVisible();

--- a/examples/event-platform/src/modules/attendee/components/ticket-holder-form.tsx
+++ b/examples/event-platform/src/modules/attendee/components/ticket-holder-form.tsx
@@ -1,14 +1,11 @@
 'use client';
 
-// oxlint-disable effecttsgo/async-function -- React Transition Actions are native Promise boundaries.
-
-import { useState, useTransition } from 'react';
+import { startTransition, useActionState } from 'react';
 
 import { RevealTransition } from '@/components/navigation-transition';
 import { Button } from '@/components/ui/button';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
-import type { TicketHolderMutationState } from '@/modules/attendee/server-functions';
 import { updateTicketHolder } from '@/modules/attendee/server-functions';
 
 export function TicketHolderForm({
@@ -18,8 +15,7 @@ export function TicketHolderForm({
   readonly holderName: string;
   readonly ticketId: string;
 }) {
-  const [state, setState] = useState<TicketHolderMutationState | null>(null);
-  const [pending, startTransition] = useTransition();
+  const [state, submit, pending] = useActionState(updateTicketHolder, null);
 
   return (
     <form
@@ -27,10 +23,7 @@ export function TicketHolderForm({
       onSubmit={(event) => {
         event.preventDefault();
         const formData = new FormData(event.currentTarget);
-        startTransition(async () => {
-          const result = await updateTicketHolder(formData);
-          startTransition(() => setState(result));
-        });
+        startTransition(() => submit(formData));
       }}
     >
       <input name='ticketId' type='hidden' value={ticketId} />

--- a/examples/event-platform/src/modules/attendee/server-functions.ts
+++ b/examples/event-platform/src/modules/attendee/server-functions.ts
@@ -5,10 +5,11 @@ import { Effect, Schema } from 'effect';
 import { AttendeeHubERSC, CurrentAttendeeSession } from '@/modules/attendee/current-attendee';
 import { AttendeeService } from '@/modules/attendee/service';
 
-export type TicketHolderMutationState = {
-  readonly message: string;
-  readonly status: 'error' | 'success';
-};
+const TicketHolderMutationState = Schema.Union([
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('success') }),
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('error') }),
+]);
+export type TicketHolderMutationState = typeof TicketHolderMutationState.Type;
 
 const HolderName = Schema.String.check(
   Schema.isTrimmed(),
@@ -23,8 +24,8 @@ const UpdateTicketHolderInput = Schema.fromFormData(
 );
 
 export const updateTicketHolder = AttendeeHubERSC.ServerFn.make({
-  input: UpdateTicketHolderInput,
-  handler: Effect.fn('updateTicketHolder')(function* ({ holderName, ticketId }) {
+  input: [Schema.NullOr(TicketHolderMutationState), UpdateTicketHolderInput],
+  handler: Effect.fn('updateTicketHolder')(function* (_previousState, { holderName, ticketId }) {
     const { token } = yield* CurrentAttendeeSession;
     const service = yield* AttendeeService;
     const outcome = yield* service.updateHolderName(token, ticketId, holderName).pipe(

--- a/examples/event-platform/src/modules/check-in/components/check-in-scanner.tsx
+++ b/examples/event-platform/src/modules/check-in/components/check-in-scanner.tsx
@@ -3,7 +3,7 @@
 // oxlint-disable effecttsgo/async-function -- React Transition Actions are native Promise boundaries.
 
 import { RotateCcw, ScanLine, UserCheck } from 'lucide-react';
-import { useRef, useState, useTransition } from 'react';
+import { startTransition, useActionState, useRef } from 'react';
 
 import { RevealTransition } from '@/components/navigation-transition';
 import { Button } from '@/components/ui/button';
@@ -14,16 +14,14 @@ import { mutateCheckIn } from '@/modules/check-in/server-functions';
 
 export function CheckInScanner({ eventId }: { readonly eventId: string }) {
   const input = useRef<HTMLInputElement>(null);
-  const [state, setState] = useState<CheckInMutationState | null>(null);
-  const [pending, startTransition] = useTransition();
-
-  const submit = (formData: FormData) => {
-    startTransition(async () => {
-      const result = await mutateCheckIn(formData);
-      startTransition(() => setState(result));
+  const [state, submit, pending] = useActionState<CheckInMutationState | null, FormData>(
+    async (previousState, form) => {
+      const result = await mutateCheckIn(previousState, form);
       input.current?.select();
-    });
-  };
+      return result;
+    },
+    null,
+  );
 
   return (
     <section aria-labelledby='credential-scanner'>
@@ -41,7 +39,8 @@ export function CheckInScanner({ eventId }: { readonly eventId: string }) {
         className='mt-5 flex flex-col gap-3 sm:flex-row'
         onSubmit={(event) => {
           event.preventDefault();
-          submit(new FormData(event.currentTarget));
+          const formData = new FormData(event.currentTarget);
+          startTransition(() => submit(formData));
         }}
       >
         <input name='eventId' type='hidden' value={eventId} />
@@ -101,7 +100,7 @@ export function CheckInScanner({ eventId }: { readonly eventId: string }) {
                       formData.set('eventId', eventId);
                       formData.set('operation', 'undo');
                       formData.set('ticketCode', state.ticket.code);
-                      submit(formData);
+                      startTransition(() => submit(formData));
                     }}
                     size='sm'
                     type='button'

--- a/examples/event-platform/src/modules/check-in/server-functions.ts
+++ b/examples/event-platform/src/modules/check-in/server-functions.ts
@@ -2,18 +2,20 @@
 
 import { Effect, Schema } from 'effect';
 
-import type { CheckInTicket } from '@/modules/check-in/model';
+import { CheckInTicket } from '@/modules/check-in/model';
 import { type CheckInError, type CheckInResult, CheckInService } from '@/modules/check-in/service';
 import { CurrentOrganizer, OrganizerERSC } from '@/modules/organizer/current-organizer';
 
-export type CheckInMutationState =
-  | {
-      readonly message: string;
-      readonly outcome: 'already_checked_in' | 'checked_in' | 'reopened';
-      readonly status: 'success';
-      readonly ticket: CheckInTicket;
-    }
-  | { readonly message: string; readonly status: 'error' };
+const CheckInMutationState = Schema.Union([
+  Schema.Struct({
+    message: Schema.String,
+    outcome: Schema.Literals(['already_checked_in', 'checked_in', 'reopened']),
+    status: Schema.Literal('success'),
+    ticket: CheckInTicket,
+  }),
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('error') }),
+]);
+export type CheckInMutationState = typeof CheckInMutationState.Type;
 
 const successState = (result: CheckInResult): CheckInMutationState => {
   switch (result._tag) {
@@ -79,8 +81,11 @@ const CredentialInput = Schema.fromFormData(
 );
 
 export const mutateCheckIn = OrganizerERSC.ServerFn.make({
-  input: CredentialInput,
-  handler: Effect.fn('mutateCheckIn')(function* ({ eventId, operation, ticketCode }) {
+  input: [Schema.NullOr(CheckInMutationState), CredentialInput],
+  handler: Effect.fn('mutateCheckIn')(function* (
+    _previousState,
+    { eventId, operation, ticketCode },
+  ) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* CheckInService;
     if (operation === 'check_in') {

--- a/examples/event-platform/src/modules/communications/components/announcement-actions.tsx
+++ b/examples/event-platform/src/modules/communications/components/announcement-actions.tsx
@@ -4,7 +4,7 @@
 // oxlint-disable effecttsgo/crypto-random-uuid -- Browser-generated idempotency keys must not pull Effect into the client graph.
 
 import { Save, Send } from 'lucide-react';
-import { useState, useTransition } from 'react';
+import { startTransition, useActionState, useRef, useState } from 'react';
 
 import { RevealTransition } from '@/components/navigation-transition';
 import { Button } from '@/components/ui/button';
@@ -32,26 +32,27 @@ function MutationMessage({ state }: { readonly state: CommunicationsMutationStat
 
 export function AnnouncementComposer({ eventId }: { readonly eventId: string }) {
   const [announcementId, setAnnouncementId] = useState(() => crypto.randomUUID());
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<CommunicationsMutationState | null>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [state, submit, pending] = useActionState<CommunicationsMutationState | null, FormData>(
+    async (previousState, form) => {
+      const next = await saveAnnouncement(previousState, form);
+      if (next.status === 'success') {
+        formRef.current?.reset();
+        setAnnouncementId(crypto.randomUUID());
+      }
+      return next;
+    },
+    null,
+  );
 
   return (
     <form
       className='grid gap-5'
+      ref={formRef}
       onSubmit={(event) => {
         event.preventDefault();
-        const form = event.currentTarget;
-        const formData = new FormData(form);
-        startTransition(async () => {
-          const next = await saveAnnouncement(formData);
-          startTransition(() => {
-            setState(next);
-            if (next.status === 'success') {
-              form.reset();
-              setAnnouncementId(crypto.randomUUID());
-            }
-          });
-        });
+        const formData = new FormData(event.currentTarget);
+        startTransition(() => submit(formData));
       }}
     >
       <input name='announcementId' type='hidden' value={announcementId} />
@@ -106,21 +107,10 @@ export function SendAnnouncementButton({
   readonly eventId: string;
   readonly retry?: boolean;
 }) {
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<CommunicationsMutationState | null>(null);
+  const [state, formAction, pending] = useActionState(sendAnnouncement, null);
 
   return (
-    <form
-      className='flex flex-wrap items-center gap-3'
-      onSubmit={(event) => {
-        event.preventDefault();
-        const formData = new FormData(event.currentTarget);
-        startTransition(async () => {
-          const next = await sendAnnouncement(formData);
-          startTransition(() => setState(next));
-        });
-      }}
-    >
+    <form action={formAction} className='flex flex-wrap items-center gap-3'>
       <input name='announcementId' type='hidden' value={announcementId} />
       <input name='eventId' type='hidden' value={eventId} />
       <Button disabled={pending} size='sm' type='submit'>

--- a/examples/event-platform/src/modules/communications/server-functions.ts
+++ b/examples/event-platform/src/modules/communications/server-functions.ts
@@ -7,9 +7,11 @@ import type { CommunicationsError } from '@/modules/communications/service';
 import { CommunicationsService } from '@/modules/communications/service';
 import { CurrentOrganizer, OrganizerERSC } from '@/modules/organizer/current-organizer';
 
-export type CommunicationsMutationState =
-  | { readonly message: string; readonly status: 'success' }
-  | { readonly message: string; readonly status: 'error' };
+const CommunicationsMutationState = Schema.Union([
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('success') }),
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('error') }),
+]);
+export type CommunicationsMutationState = typeof CommunicationsMutationState.Type;
 
 const RequiredText = (maximum: number) =>
   Schema.String.check(Schema.isTrimmed(), Schema.isMinLength(1), Schema.isMaxLength(maximum));
@@ -48,8 +50,8 @@ const result = <A>(effect: Effect.Effect<A, CommunicationsError>, message: (valu
   );
 
 export const saveAnnouncement = OrganizerERSC.ServerFn.make({
-  input: SaveAnnouncementInput,
-  handler: Effect.fn('saveAnnouncement')(function* (input) {
+  input: [Schema.NullOr(CommunicationsMutationState), SaveAnnouncementInput],
+  handler: Effect.fn('saveAnnouncement')(function* (_previousState, input) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* CommunicationsService;
     return yield* result(service.saveDraft(userId, input), () => 'Announcement draft saved.');
@@ -57,8 +59,8 @@ export const saveAnnouncement = OrganizerERSC.ServerFn.make({
 });
 
 export const sendAnnouncement = OrganizerERSC.ServerFn.make({
-  input: SendAnnouncementInput,
-  handler: Effect.fn('sendAnnouncement')(function* ({ announcementId, eventId }) {
+  input: [Schema.NullOr(CommunicationsMutationState), SendAnnouncementInput],
+  handler: Effect.fn('sendAnnouncement')(function* (_previousState, { announcementId, eventId }) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* CommunicationsService;
     return yield* result(service.send(userId, eventId, announcementId), ({ recipientCount }) =>

--- a/examples/event-platform/src/modules/event-authoring/components/authoring-forms.tsx
+++ b/examples/event-platform/src/modules/event-authoring/components/authoring-forms.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-// oxlint-disable effecttsgo/async-function -- React Transition Actions are native Promise boundaries.
-
 import { Eye, EyeOff, Save, Ticket, WandSparkles } from 'lucide-react';
-import { type ReactNode, useState, useTransition } from 'react';
+import { type ReactNode, startTransition, useActionState } from 'react';
 
 import { RevealTransition } from '@/components/navigation-transition';
 import { Button } from '@/components/ui/button';
@@ -52,7 +50,7 @@ function MutationMessage({ state }: { readonly state: AuthoringMutationState | n
         }
       >
         <span>{state.message}</span>
-        {state.status === 'success' && state.editPath !== undefined ? (
+        {state.status === 'success' && state.editPath !== null ? (
           <a
             className='text-foreground font-medium underline underline-offset-4'
             href={state.editPath}
@@ -97,9 +95,8 @@ export function EventDetailsForm({
   readonly defaults?: EditableEvent;
   readonly organizationId: string;
 }) {
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<AuthoringMutationState | null>(null);
   const editing = defaults !== undefined;
+  const [state, submit, pending] = useActionState(editing ? updateEvent : createEvent, null);
 
   return (
     <form
@@ -107,10 +104,7 @@ export function EventDetailsForm({
       onSubmit={(event) => {
         event.preventDefault();
         const formData = new FormData(event.currentTarget);
-        startTransition(async () => {
-          const next = await (editing ? updateEvent(formData) : createEvent(formData));
-          startTransition(() => setState(next));
-        });
+        startTransition(() => submit(formData));
       }}
     >
       {editing ? (
@@ -255,6 +249,10 @@ export function EventDetailsForm({
   );
 }
 
+type TicketTypeAction =
+  | { readonly _tag: 'Save'; readonly form: FormData }
+  | { readonly _tag: 'SetStatus'; readonly input: Parameters<typeof setTicketTypeStatus>[0] };
+
 export function TicketTypeForm({
   eventId,
   ticket,
@@ -262,8 +260,13 @@ export function TicketTypeForm({
   readonly eventId: string;
   readonly ticket?: ManagedTicketType;
 }) {
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<AuthoringMutationState | null>(null);
+  const [state, submit, pending] = useActionState<AuthoringMutationState | null, TicketTypeAction>(
+    (previousState, action) =>
+      action._tag === 'Save'
+        ? saveTicketType(previousState, action.form)
+        : setTicketTypeStatus(action.input),
+    null,
+  );
   const fieldPrefix = ticket?.ticketTypeId ?? 'new-ticket';
   const fieldId = (name: string) => `${fieldPrefix}-${name}`;
 
@@ -273,10 +276,7 @@ export function TicketTypeForm({
       onSubmit={(event) => {
         event.preventDefault();
         const formData = new FormData(event.currentTarget);
-        startTransition(async () => {
-          const next = await saveTicketType(formData);
-          startTransition(() => setState(next));
-        });
+        startTransition(() => submit({ _tag: 'Save', form: formData }));
       }}
     >
       <input name='eventId' type='hidden' value={eventId} />
@@ -381,14 +381,16 @@ export function TicketTypeForm({
           <Button
             disabled={pending}
             onClick={() => {
-              startTransition(async () => {
-                const next = await setTicketTypeStatus({
-                  eventId,
-                  status: ticket.status === 'active' ? 'hidden' : 'active',
-                  ticketTypeId: ticket.ticketTypeId,
-                });
-                startTransition(() => setState(next));
-              });
+              startTransition(() =>
+                submit({
+                  _tag: 'SetStatus',
+                  input: {
+                    eventId,
+                    status: ticket.status === 'active' ? 'hidden' : 'active',
+                    ticketTypeId: ticket.ticketTypeId,
+                  },
+                }),
+              );
             }}
             size='sm'
             type='button'

--- a/examples/event-platform/src/modules/event-authoring/server-functions.ts
+++ b/examples/event-platform/src/modules/event-authoring/server-functions.ts
@@ -6,9 +6,15 @@ import type { EventAuthoringError } from '@/modules/event-authoring/service';
 import { EventAuthoringService } from '@/modules/event-authoring/service';
 import { CurrentOrganizer, OrganizerERSC } from '@/modules/organizer/current-organizer';
 
-export type AuthoringMutationState =
-  | { readonly editPath?: string; readonly message: string; readonly status: 'success' }
-  | { readonly message: string; readonly status: 'error' };
+const AuthoringMutationState = Schema.Union([
+  Schema.Struct({
+    editPath: Schema.NullOr(Schema.String),
+    message: Schema.String,
+    status: Schema.Literal('success'),
+  }),
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('error') }),
+]);
+export type AuthoringMutationState = typeof AuthoringMutationState.Type;
 
 const RequiredText = (maximum: number) =>
   Schema.String.check(Schema.isTrimmed(), Schema.isMinLength(1), Schema.isMaxLength(maximum));
@@ -106,8 +112,8 @@ const result = <A, E extends EventAuthoringError>(
   );
 
 export const createEvent = OrganizerERSC.ServerFn.make({
-  input: CreateEventInput,
-  handler: Effect.fn('createEvent')(function* (input) {
+  input: [Schema.NullOr(AuthoringMutationState), CreateEventInput],
+  handler: Effect.fn('createEvent')(function* (_previousState, input) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* EventAuthoringService;
     return yield* result(service.createEvent(userId, input), ({ eventId }) => ({
@@ -119,11 +125,12 @@ export const createEvent = OrganizerERSC.ServerFn.make({
 });
 
 export const updateEvent = OrganizerERSC.ServerFn.make({
-  input: UpdateEventInput,
-  handler: Effect.fn('updateEvent')(function* (input) {
+  input: [Schema.NullOr(AuthoringMutationState), UpdateEventInput],
+  handler: Effect.fn('updateEvent')(function* (_previousState, input) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* EventAuthoringService;
     return yield* result(service.updateEvent(userId, input), () => ({
+      editPath: null,
       message: 'Event details saved.',
       status: 'success',
     }));
@@ -131,11 +138,12 @@ export const updateEvent = OrganizerERSC.ServerFn.make({
 });
 
 export const saveTicketType = OrganizerERSC.ServerFn.make({
-  input: SaveTicketTypeInput,
-  handler: Effect.fn('saveTicketType')(function* (input) {
+  input: [Schema.NullOr(AuthoringMutationState), SaveTicketTypeInput],
+  handler: Effect.fn('saveTicketType')(function* (_previousState, input) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* EventAuthoringService;
     return yield* result(service.saveTicketType(userId, input), ({ operation }) => ({
+      editPath: null,
       message: operation === 'created' ? 'Ticket type created.' : 'Ticket type saved.',
       status: 'success',
     }));
@@ -150,6 +158,7 @@ export const setTicketTypeStatus = OrganizerERSC.ServerFn.make({
     return yield* result(
       service.setTicketTypeStatus(userId, eventId, ticketTypeId, status),
       (updated) => ({
+        editPath: null,
         message: updated.status === 'active' ? 'Ticket is on sale.' : 'Ticket is hidden.',
         status: 'success',
       }),

--- a/examples/event-platform/src/modules/orders/components/refund-order-action.tsx
+++ b/examples/event-platform/src/modules/orders/components/refund-order-action.tsx
@@ -3,7 +3,7 @@
 // oxlint-disable effecttsgo/async-function -- React Transition Actions are native Promise boundaries.
 
 import { RotateCcw, TriangleAlert } from 'lucide-react';
-import { useState, useTransition } from 'react';
+import { startTransition, useActionState, useState } from 'react';
 
 import { RevealTransition } from '@/components/navigation-transition';
 import {
@@ -25,8 +25,16 @@ import { refundOrder } from '@/modules/orders/server-functions';
 
 export function RefundOrderAction({ eventId, orderId }: { eventId: string; orderId: string }) {
   const [open, setOpen] = useState(false);
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<OrderMutationState | null>(null);
+  const [state, submit, pending] = useActionState<OrderMutationState | null, FormData>(
+    async (previousState, form) => {
+      const next = await refundOrder(previousState, form);
+      if (next.status === 'success') {
+        startTransition(() => setOpen(false));
+      }
+      return next;
+    },
+    null,
+  );
 
   return (
     <div className='grid gap-2'>
@@ -54,15 +62,7 @@ export function RefundOrderAction({ eventId, orderId }: { eventId: string; order
             onSubmit={(event) => {
               event.preventDefault();
               const formData = new FormData(event.currentTarget);
-              startTransition(async () => {
-                const next = await refundOrder(formData);
-                startTransition(() => {
-                  setState(next);
-                  if (next.status === 'success') {
-                    setOpen(false);
-                  }
-                });
-              });
+              startTransition(() => submit(formData));
             }}
           >
             <input name='eventId' type='hidden' value={eventId} />

--- a/examples/event-platform/src/modules/orders/server-functions.ts
+++ b/examples/event-platform/src/modules/orders/server-functions.ts
@@ -6,9 +6,11 @@ import type { OrdersError } from '@/modules/orders/service';
 import { OrdersService } from '@/modules/orders/service';
 import { CurrentOrganizer, OrganizerERSC } from '@/modules/organizer/current-organizer';
 
-export type OrderMutationState =
-  | { readonly message: string; readonly status: 'success' }
-  | { readonly message: string; readonly status: 'error' };
+const OrderMutationState = Schema.Union([
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('success') }),
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('error') }),
+]);
+export type OrderMutationState = typeof OrderMutationState.Type;
 
 const RefundInput = Schema.fromFormData(
   Schema.Struct({
@@ -30,8 +32,8 @@ const failureState = (error: OrdersError): OrderMutationState => {
 };
 
 export const refundOrder = OrganizerERSC.ServerFn.make({
-  input: RefundInput,
-  handler: Effect.fn('refundOrder')(function* ({ eventId, orderId, reason }) {
+  input: [Schema.NullOr(OrderMutationState), RefundInput],
+  handler: Effect.fn('refundOrder')(function* (_previousState, { eventId, orderId, reason }) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* OrdersService;
     return yield* service.refund(userId, eventId, orderId, reason).pipe(

--- a/examples/event-platform/src/modules/organizer/components/event-status-action.tsx
+++ b/examples/event-platform/src/modules/organizer/components/event-status-action.tsx
@@ -18,19 +18,27 @@ import {
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import type { EventStatusMutationState } from '@/modules/organizer/server-functions';
+import { transitionEventStatus } from '@/modules/organizer/server-functions';
 
 type EventStatusActionProps = {
-  readonly action: () => Promise<EventStatusMutationState>;
+  readonly eventId: string;
   readonly id: string;
   readonly label: string;
+  readonly targetStatus: 'published' | 'cancelled' | 'completed';
   readonly variant: 'default' | 'destructive' | 'outline';
 };
 
-export function EventStatusAction({ action, id, label, variant }: EventStatusActionProps) {
+export function EventStatusAction({
+  eventId,
+  id,
+  label,
+  targetStatus,
+  variant,
+}: EventStatusActionProps) {
   const [open, setOpen] = useState(false);
   const [state, formAction, pending] = useActionState<EventStatusMutationState | null>(
     () =>
-      action().then((next) => {
+      transitionEventStatus({ eventId, targetStatus }).then((next) => {
         if (next.status === 'success') {
           startTransition(() => setOpen(false));
         }

--- a/examples/event-platform/src/modules/organizer/components/organizer-dashboard.tsx
+++ b/examples/event-platform/src/modules/organizer/components/organizer-dashboard.tsx
@@ -31,7 +31,6 @@ import { EventStatusAction } from '@/modules/organizer/components/event-status-a
 import { CurrentOrganizer, OrganizerERSC } from '@/modules/organizer/current-organizer';
 import type { ManagedEvent, ManagedEventStatus, OrganizationRole } from '@/modules/organizer/model';
 import { OrganizerAccessDenied } from '@/modules/organizer/model';
-import { transitionEventStatus } from '@/modules/organizer/server-functions';
 import { availableEventTransitions, OrganizerService } from '@/modules/organizer/service';
 
 const statusVariant = (status: ManagedEventStatus) => {
@@ -161,22 +160,16 @@ function ManagedEventCard({
           <p className='text-muted-foreground mt-5 text-sm'>This lifecycle is final.</p>
         ) : canManage ? (
           <div className='mt-5 grid gap-3'>
-            {transitions.map((targetStatus) => {
-              const action = transitionEventStatus.bind(null, {
-                eventId: event.eventId,
-                targetStatus,
-              });
-
-              return (
-                <EventStatusAction
-                  action={action}
-                  id={`event-status-${event.eventId}-${targetStatus}`}
-                  key={targetStatus}
-                  label={transitionLabel(targetStatus)}
-                  variant={targetStatus === 'cancelled' ? 'destructive' : 'default'}
-                />
-              );
-            })}
+            {transitions.map((targetStatus) => (
+              <EventStatusAction
+                eventId={event.eventId}
+                id={`event-status-${event.eventId}-${targetStatus}`}
+                key={targetStatus}
+                label={transitionLabel(targetStatus)}
+                targetStatus={targetStatus}
+                variant={targetStatus === 'cancelled' ? 'destructive' : 'default'}
+              />
+            ))}
           </div>
         ) : null}
       </CardContent>

--- a/examples/event-platform/src/modules/programme/components/programme-forms.tsx
+++ b/examples/event-platform/src/modules/programme/components/programme-forms.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-// oxlint-disable effecttsgo/async-function -- React Transition Actions are native Promise boundaries.
-
 import { Eye, EyeOff, Save, Undo2 } from 'lucide-react';
-import { type ReactNode, useState, useTransition } from 'react';
+import { type ReactNode, startTransition, useActionState, useState } from 'react';
 
 import { RevealTransition } from '@/components/navigation-transition';
 import { Button } from '@/components/ui/button';
@@ -56,8 +54,7 @@ export function RoomForm({
   readonly eventId: string;
   readonly room?: ProgrammeRoom;
 }) {
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<ProgrammeMutationState | null>(null);
+  const [state, submit, pending] = useActionState(saveRoom, null);
   const prefix = room?.roomId ?? 'new-room';
 
   return (
@@ -66,10 +63,7 @@ export function RoomForm({
       onSubmit={(event) => {
         event.preventDefault();
         const formData = new FormData(event.currentTarget);
-        startTransition(async () => {
-          const next = await saveRoom(formData);
-          startTransition(() => setState(next));
-        });
+        startTransition(() => submit(formData));
       }}
     >
       <input name='eventId' type='hidden' value={eventId} />
@@ -114,8 +108,7 @@ export function SpeakerForm({
   readonly eventId: string;
   readonly speaker?: ProgrammeSpeaker;
 }) {
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<ProgrammeMutationState | null>(null);
+  const [state, submit, pending] = useActionState(saveSpeaker, null);
   const prefix = speaker?.speakerId ?? 'new-speaker';
 
   return (
@@ -124,10 +117,7 @@ export function SpeakerForm({
       onSubmit={(event) => {
         event.preventDefault();
         const formData = new FormData(event.currentTarget);
-        startTransition(async () => {
-          const next = await saveSpeaker(formData);
-          startTransition(() => setState(next));
-        });
+        startTransition(() => submit(formData));
       }}
     >
       <input name='eventId' type='hidden' value={eventId} />
@@ -185,6 +175,10 @@ export function SpeakerForm({
   );
 }
 
+type SessionAction =
+  | { readonly _tag: 'Save'; readonly form: FormData }
+  | { readonly _tag: 'SetStatus'; readonly input: Parameters<typeof setSessionStatus>[0] };
+
 export function SessionForm({
   event,
   rooms,
@@ -196,8 +190,13 @@ export function SessionForm({
   readonly session?: ProgrammeSession;
   readonly speakers: ReadonlyArray<ProgrammeSpeaker>;
 }) {
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<ProgrammeMutationState | null>(null);
+  const [state, submit, pending] = useActionState<ProgrammeMutationState | null, SessionAction>(
+    (previousState, action) =>
+      action._tag === 'Save'
+        ? saveSession(previousState, action.form)
+        : setSessionStatus(action.input),
+    null,
+  );
   const prefix = session?.sessionId ?? 'new-session';
   const canCreate = rooms.length > 0 && speakers.length > 0;
   const [capacity, setCapacity] = useState(() =>
@@ -210,10 +209,7 @@ export function SessionForm({
       onSubmit={(submitEvent) => {
         submitEvent.preventDefault();
         const formData = new FormData(submitEvent.currentTarget);
-        startTransition(async () => {
-          const next = await saveSession(formData);
-          startTransition(() => setState(next));
-        });
+        startTransition(() => submit({ _tag: 'Save', form: formData }));
       }}
     >
       <input name='eventId' type='hidden' value={event.eventId} />
@@ -324,14 +320,16 @@ export function SessionForm({
           <Button
             disabled={pending}
             onClick={() => {
-              startTransition(async () => {
-                const next = await setSessionStatus({
-                  eventId: event.eventId,
-                  sessionId: session.sessionId,
-                  status: session.status === 'published' ? 'draft' : 'published',
-                });
-                startTransition(() => setState(next));
-              });
+              startTransition(() =>
+                submit({
+                  _tag: 'SetStatus',
+                  input: {
+                    eventId: event.eventId,
+                    sessionId: session.sessionId,
+                    status: session.status === 'published' ? 'draft' : 'published',
+                  },
+                }),
+              );
             }}
             size='sm'
             type='button'
@@ -349,14 +347,16 @@ export function SessionForm({
           <Button
             disabled={pending}
             onClick={() => {
-              startTransition(async () => {
-                const next = await setSessionStatus({
-                  eventId: event.eventId,
-                  sessionId: session.sessionId,
-                  status: 'cancelled',
-                });
-                startTransition(() => setState(next));
-              });
+              startTransition(() =>
+                submit({
+                  _tag: 'SetStatus',
+                  input: {
+                    eventId: event.eventId,
+                    sessionId: session.sessionId,
+                    status: 'cancelled',
+                  },
+                }),
+              );
             }}
             size='sm'
             type='button'

--- a/examples/event-platform/src/modules/programme/server-functions.ts
+++ b/examples/event-platform/src/modules/programme/server-functions.ts
@@ -6,9 +6,11 @@ import { CurrentOrganizer, OrganizerERSC } from '@/modules/organizer/current-org
 import type { ProgrammeError } from '@/modules/programme/service';
 import { ProgrammeService } from '@/modules/programme/service';
 
-export type ProgrammeMutationState =
-  | { readonly message: string; readonly status: 'success' }
-  | { readonly message: string; readonly status: 'error' };
+const ProgrammeMutationState = Schema.Union([
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('success') }),
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('error') }),
+]);
+export type ProgrammeMutationState = typeof ProgrammeMutationState.Type;
 
 const RequiredText = (maximum: number) =>
   Schema.String.check(Schema.isTrimmed(), Schema.isMinLength(1), Schema.isMaxLength(maximum));
@@ -92,8 +94,8 @@ const result = <A>(effect: Effect.Effect<A, ProgrammeError>, message: (value: A)
   );
 
 export const saveRoom = OrganizerERSC.ServerFn.make({
-  input: SaveRoomInput,
-  handler: Effect.fn('saveRoom')(function* (input) {
+  input: [Schema.NullOr(ProgrammeMutationState), SaveRoomInput],
+  handler: Effect.fn('saveRoom')(function* (_previousState, input) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* ProgrammeService;
     return yield* result(service.saveRoom(userId, input), ({ operation }) =>
@@ -103,8 +105,8 @@ export const saveRoom = OrganizerERSC.ServerFn.make({
 });
 
 export const saveSpeaker = OrganizerERSC.ServerFn.make({
-  input: SaveSpeakerInput,
-  handler: Effect.fn('saveSpeaker')(function* (input) {
+  input: [Schema.NullOr(ProgrammeMutationState), SaveSpeakerInput],
+  handler: Effect.fn('saveSpeaker')(function* (_previousState, input) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* ProgrammeService;
     return yield* result(service.saveSpeaker(userId, input), ({ operation }) =>
@@ -114,8 +116,8 @@ export const saveSpeaker = OrganizerERSC.ServerFn.make({
 });
 
 export const saveSession = OrganizerERSC.ServerFn.make({
-  input: SaveSessionInput,
-  handler: Effect.fn('saveSession')(function* (input) {
+  input: [Schema.NullOr(ProgrammeMutationState), SaveSessionInput],
+  handler: Effect.fn('saveSession')(function* (_previousState, input) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* ProgrammeService;
     return yield* result(service.saveSession(userId, input), ({ operation }) =>

--- a/examples/event-platform/src/modules/registration-settings/components/registration-question-actions.tsx
+++ b/examples/event-platform/src/modules/registration-settings/components/registration-question-actions.tsx
@@ -4,7 +4,7 @@
 // oxlint-disable effecttsgo/crypto-random-uuid -- Browser-generated mutation identifiers must not pull Effect into the client graph.
 
 import { Archive, Plus } from 'lucide-react';
-import { useState, useTransition } from 'react';
+import { startTransition, useActionState, useRef, useState } from 'react';
 
 import { RevealTransition } from '@/components/navigation-transition';
 import { Button } from '@/components/ui/button';
@@ -34,27 +34,27 @@ function MutationMessage({ state }: { state: RegistrationSettingsMutationState |
 export function CreateRegistrationQuestion({ eventId }: { readonly eventId: string }) {
   // oxlint-disable-next-line effecttsgo/crypto-random-uuid -- The browser owns the question identifier before invoking the Server Function.
   const [questionId, setQuestionId] = useState(() => crypto.randomUUID());
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<RegistrationSettingsMutationState | null>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [state, submit, pending] = useActionState<
+    RegistrationSettingsMutationState | null,
+    FormData
+  >(async (previousState, form) => {
+    const result = await createRegistrationQuestion(previousState, form);
+    if (result.status === 'success') {
+      formRef.current?.reset();
+      setQuestionId(crypto.randomUUID());
+    }
+    return result;
+  }, null);
 
   return (
     <form
       className='grid gap-5'
+      ref={formRef}
       onSubmit={(event) => {
         event.preventDefault();
-        const form = event.currentTarget;
-        const formData = new FormData(form);
-        startTransition(async () => {
-          const result = await createRegistrationQuestion(formData);
-          startTransition(() => {
-            setState(result);
-            if (result.status === 'success') {
-              form.reset();
-              // oxlint-disable-next-line effecttsgo/crypto-random-uuid -- Each new question receives a browser-owned identifier.
-              setQuestionId(crypto.randomUUID());
-            }
-          });
-        });
+        const formData = new FormData(event.currentTarget);
+        startTransition(() => submit(formData));
       }}
     >
       <input name='eventId' type='hidden' value={eventId} />
@@ -111,21 +111,10 @@ export function ArchiveRegistrationQuestion({
   readonly eventId: string;
   readonly questionId: string;
 }) {
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<RegistrationSettingsMutationState | null>(null);
+  const [state, formAction, pending] = useActionState(archiveRegistrationQuestion, null);
 
   return (
-    <form
-      className='grid justify-items-end gap-2'
-      onSubmit={(event) => {
-        event.preventDefault();
-        const formData = new FormData(event.currentTarget);
-        startTransition(async () => {
-          const result = await archiveRegistrationQuestion(formData);
-          startTransition(() => setState(result));
-        });
-      }}
-    >
+    <form action={formAction} className='grid justify-items-end gap-2'>
       <input name='eventId' type='hidden' value={eventId} />
       <input name='questionId' type='hidden' value={questionId} />
       <Button disabled={pending} size='sm' type='submit' variant='outline'>

--- a/examples/event-platform/src/modules/registration-settings/server-functions.ts
+++ b/examples/event-platform/src/modules/registration-settings/server-functions.ts
@@ -6,9 +6,11 @@ import { CurrentOrganizer, OrganizerERSC } from '@/modules/organizer/current-org
 import type { RegistrationSettingsError } from '@/modules/registration-settings/service';
 import { RegistrationSettingsService } from '@/modules/registration-settings/service';
 
-export type RegistrationSettingsMutationState =
-  | { readonly message: string; readonly status: 'success' }
-  | { readonly message: string; readonly status: 'error' };
+const RegistrationSettingsMutationState = Schema.Union([
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('success') }),
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('error') }),
+]);
+export type RegistrationSettingsMutationState = typeof RegistrationSettingsMutationState.Type;
 
 const RequiredText = (maximum: number) =>
   Schema.String.check(Schema.isTrimmed(), Schema.isMinLength(1), Schema.isMaxLength(maximum));
@@ -44,8 +46,8 @@ const failureState = (error: RegistrationSettingsError): RegistrationSettingsMut
 };
 
 export const createRegistrationQuestion = OrganizerERSC.ServerFn.make({
-  input: CreateInput,
-  handler: Effect.fn('createRegistrationQuestion')(function* (input) {
+  input: [Schema.NullOr(RegistrationSettingsMutationState), CreateInput],
+  handler: Effect.fn('createRegistrationQuestion')(function* (_previousState, input) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* RegistrationSettingsService;
     return yield* service
@@ -62,8 +64,11 @@ export const createRegistrationQuestion = OrganizerERSC.ServerFn.make({
 });
 
 export const archiveRegistrationQuestion = OrganizerERSC.ServerFn.make({
-  input: ArchiveInput,
-  handler: Effect.fn('archiveRegistrationQuestion')(function* ({ eventId, questionId }) {
+  input: [Schema.NullOr(RegistrationSettingsMutationState), ArchiveInput],
+  handler: Effect.fn('archiveRegistrationQuestion')(function* (
+    _previousState,
+    { eventId, questionId },
+  ) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* RegistrationSettingsService;
     return yield* service.archive(userId, eventId, questionId).pipe(

--- a/examples/event-platform/src/modules/registration/components/registration-form.tsx
+++ b/examples/event-platform/src/modules/registration/components/registration-form.tsx
@@ -4,7 +4,7 @@
 // oxlint-disable effecttsgo/crypto-random-uuid -- Browser-generated idempotency keys must not pull Effect into the client graph.
 
 import { CheckCircle2, CreditCard, Ticket } from 'lucide-react';
-import { useState, useTransition } from 'react';
+import { startTransition, useActionState, useState } from 'react';
 
 import { RevealTransition } from '@/components/navigation-transition';
 import { Button } from '@/components/ui/button';
@@ -42,8 +42,16 @@ export function RegistrationForm({
 }) {
   // oxlint-disable-next-line effecttsgo/crypto-random-uuid -- The browser owns this checkout-attempt key before invoking the Server Function.
   const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
-  const [state, setState] = useState<RegistrationState | null>(null);
-  const [pending, startTransition] = useTransition();
+  const [state, submit, pending] = useActionState<RegistrationState | null, FormData>(
+    async (previousState, form) => {
+      const result = await registerAttendee(previousState, form);
+      if (result.status === 'error') {
+        setIdempotencyKey(crypto.randomUUID());
+      }
+      return result;
+    },
+    null,
+  );
   const firstAvailableTicket = tickets.find((ticket) => ticket.available > 0);
 
   if (state?.status === 'success') {
@@ -110,16 +118,8 @@ export function RegistrationForm({
               }),
             ),
           );
-          startTransition(async () => {
-            const result = await registerAttendee(formData);
-            startTransition(() => {
-              setState(result);
-              if (result.status === 'error') {
-                // oxlint-disable-next-line effecttsgo/crypto-random-uuid -- A known failed attempt receives a fresh browser-owned idempotency key.
-                setIdempotencyKey(crypto.randomUUID());
-              }
-            });
-          });
+          // Keep values on expected failures instead of triggering the native form-action reset.
+          startTransition(() => submit(formData));
         }}
       >
         <input name='eventId' type='hidden' value={eventId} />

--- a/examples/event-platform/src/modules/registration/server-functions.ts
+++ b/examples/event-platform/src/modules/registration/server-functions.ts
@@ -3,12 +3,14 @@
 import { Effect, Schema } from 'effect';
 
 import { ERSC } from '@/ersc';
-import { RegistrationAnswerInput, type CheckoutReceipt } from '@/modules/registration/model';
+import { RegistrationAnswerInput, CheckoutReceipt } from '@/modules/registration/model';
 import { RegistrationService } from '@/modules/registration/service';
 
-export type RegistrationState =
-  | { readonly message: string; readonly status: 'error' }
-  | { readonly receipt: CheckoutReceipt; readonly status: 'success' };
+const RegistrationState = Schema.Union([
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('error') }),
+  Schema.Struct({ receipt: CheckoutReceipt, status: Schema.Literal('success') }),
+]);
+export type RegistrationState = typeof RegistrationState.Type;
 
 const PersonName = Schema.String.check(
   Schema.isTrimmed(),
@@ -35,8 +37,8 @@ const RegistrationInput = Schema.fromFormData(
 );
 
 export const registerAttendee = ERSC.ServerFn.make({
-  input: RegistrationInput,
-  handler: Effect.fn('registerAttendee')(function* (input) {
+  input: [Schema.NullOr(RegistrationState), RegistrationInput],
+  handler: Effect.fn('registerAttendee')(function* (_previousState, input) {
     const service = yield* RegistrationService;
     const outcome = yield* service.checkout(input).pipe(
       Effect.map((receipt) => ({ receipt, _tag: 'Success' }) as const),

--- a/examples/event-platform/src/modules/waitlist/components/notify-waitlist-action.tsx
+++ b/examples/event-platform/src/modules/waitlist/components/notify-waitlist-action.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-// oxlint-disable effecttsgo/async-function -- React Transition Actions are native Promise boundaries.
-
 import { Send } from 'lucide-react';
-import { useState, useTransition } from 'react';
+import { useActionState } from 'react';
 
 import { RevealTransition } from '@/components/navigation-transition';
 import { Button } from '@/components/ui/button';
-import type { WaitlistMutationState } from '@/modules/waitlist/server-functions';
 import { notifyWaitlistEntry } from '@/modules/waitlist/server-functions';
 
 export function NotifyWaitlistAction({
@@ -17,21 +14,10 @@ export function NotifyWaitlistAction({
   readonly entryId: string;
   readonly eventId: string;
 }) {
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<WaitlistMutationState | null>(null);
+  const [state, formAction, pending] = useActionState(notifyWaitlistEntry, null);
 
   return (
-    <form
-      className='grid justify-items-end gap-2'
-      onSubmit={(event) => {
-        event.preventDefault();
-        const formData = new FormData(event.currentTarget);
-        startTransition(async () => {
-          const result = await notifyWaitlistEntry(formData);
-          startTransition(() => setState(result));
-        });
-      }}
-    >
+    <form action={formAction} className='grid justify-items-end gap-2'>
       <input name='entryId' type='hidden' value={entryId} />
       <input name='eventId' type='hidden' value={eventId} />
       <Button disabled={pending} size='sm' type='submit' variant='outline'>

--- a/examples/event-platform/src/modules/waitlist/components/waitlist-form.tsx
+++ b/examples/event-platform/src/modules/waitlist/components/waitlist-form.tsx
@@ -4,7 +4,7 @@
 // oxlint-disable effecttsgo/crypto-random-uuid -- Browser-generated idempotency keys must not pull Effect into the client graph.
 
 import { BellRing } from 'lucide-react';
-import { useState, useTransition } from 'react';
+import { startTransition, useActionState, useState } from 'react';
 
 import { RevealTransition } from '@/components/navigation-transition';
 import { Button } from '@/components/ui/button';
@@ -24,8 +24,16 @@ export function WaitlistForm({
 }) {
   // oxlint-disable-next-line effecttsgo/crypto-random-uuid -- The browser owns this join-attempt key before invoking the Server Function.
   const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
-  const [pending, startTransition] = useTransition();
-  const [state, setState] = useState<WaitlistMutationState | null>(null);
+  const [state, submit, pending] = useActionState<WaitlistMutationState | null, FormData>(
+    async (previousState, form) => {
+      const result = await joinWaitlist(previousState, form);
+      if (result.status === 'error') {
+        setIdempotencyKey(crypto.randomUUID());
+      }
+      return result;
+    },
+    null,
+  );
 
   if (tickets.length === 0) {
     return null;
@@ -46,16 +54,7 @@ export function WaitlistForm({
         onSubmit={(event) => {
           event.preventDefault();
           const formData = new FormData(event.currentTarget);
-          startTransition(async () => {
-            const result = await joinWaitlist(formData);
-            startTransition(() => {
-              setState(result);
-              if (result.status === 'error') {
-                // oxlint-disable-next-line effecttsgo/crypto-random-uuid -- A rejected attempt receives a fresh browser-owned key.
-                setIdempotencyKey(crypto.randomUUID());
-              }
-            });
-          });
+          startTransition(() => submit(formData));
         }}
       >
         <input name='eventId' type='hidden' value={eventId} />

--- a/examples/event-platform/src/modules/waitlist/server-functions.ts
+++ b/examples/event-platform/src/modules/waitlist/server-functions.ts
@@ -7,9 +7,11 @@ import { CurrentOrganizer, OrganizerERSC } from '@/modules/organizer/current-org
 import type { WaitlistError } from '@/modules/waitlist/service';
 import { WaitlistService } from '@/modules/waitlist/service';
 
-export type WaitlistMutationState =
-  | { readonly message: string; readonly status: 'success' }
-  | { readonly message: string; readonly status: 'error' };
+const WaitlistMutationState = Schema.Union([
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('success') }),
+  Schema.Struct({ message: Schema.String, status: Schema.Literal('error') }),
+]);
+export type WaitlistMutationState = typeof WaitlistMutationState.Type;
 
 const PersonName = Schema.String.check(
   Schema.isTrimmed(),
@@ -73,8 +75,8 @@ export const joinWaitlist = ERSC.ServerFn.make({
 });
 
 export const notifyWaitlistEntry = OrganizerERSC.ServerFn.make({
-  input: NotifyInput,
-  handler: Effect.fn('notifyWaitlistEntry')(function* ({ entryId, eventId }) {
+  input: [Schema.NullOr(WaitlistMutationState), NotifyInput],
+  handler: Effect.fn('notifyWaitlistEntry')(function* (_previousState, { entryId, eventId }) {
     const { userId } = yield* CurrentOrganizer;
     const service = yield* WaitlistService;
     return yield* service.notify(userId, eventId, entryId).pipe(

--- a/examples/event-platform/src/modules/waitlist/server-functions.ts
+++ b/examples/event-platform/src/modules/waitlist/server-functions.ts
@@ -55,8 +55,8 @@ const failureState = (error: WaitlistError): WaitlistMutationState => {
 };
 
 export const joinWaitlist = ERSC.ServerFn.make({
-  input: JoinInput,
-  handler: Effect.fn('joinWaitlist')(function* ({ idempotencyKey, ...input }) {
+  input: [Schema.NullOr(WaitlistMutationState), JoinInput],
+  handler: Effect.fn('joinWaitlist')(function* (_previousState, { idempotencyKey, ...input }) {
     const service = yield* WaitlistService;
     return yield* service.join(input, idempotencyKey).pipe(
       Effect.map(

--- a/fixtures/framework-e2e/e2e/server-functions.spec.ts
+++ b/fixtures/framework-e2e/e2e/server-functions.spec.ts
@@ -58,6 +58,14 @@ test.describe('Server Functions', () => {
       await expect(selection).toContainText(title);
       expect(await readCatalogFallbackObservation(page)).toBe(false);
 
+      // The second submission sends the previous result object, not the initial null state.
+      await item.getByRole('button', { name: 'Remove from the selection' }).click();
+      await expect(item.getByText("Removed from Integration Actor's selection.")).toBeVisible();
+      await waitForViewTransition(page, ['server-function']);
+      await item.getByRole('button', { name: 'Add to the selection' }).click();
+      await expect(item.getByText("Added to Integration Actor's selection.")).toBeVisible();
+      await waitForViewTransition(page, ['server-function']);
+
       await page.reload();
       item = itemCard(page, title);
       await expect(item.getByRole('button', { name: 'Remove from the selection' })).toBeVisible();
@@ -105,6 +113,44 @@ test.describe('Server Functions', () => {
         timeout: 15_000,
       });
       await setItemSelection(page, title, false);
+    }
+  });
+});
+
+test.describe('stateful forms without JavaScript', () => {
+  test.use({ javaScriptEnabled: false });
+
+  test('round-trips previous state and FormData across successive submissions', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    try {
+      const item = page.locator('form');
+      let previousMessage: string | null = null;
+      for (const [button, message] of [
+        ['Add to the selection', 'Added to the selection.'],
+        ['Remove from the selection', 'Removed from the selection.'],
+      ] as const) {
+        const [response] = await Promise.all([
+          page.waitForResponse(
+            (response) =>
+              response.request().isNavigationRequest() && response.request().method() === 'POST',
+          ),
+          item.getByRole('button', { name: button }).click(),
+        ]);
+        expect(response.status()).toBe(200);
+        if (previousMessage !== null) {
+          expect(response.request().postData()).toContain(previousMessage);
+        }
+        await expect(item.getByText(message)).toBeVisible();
+        previousMessage = message;
+      }
+    } finally {
+      const remove = page.getByRole('button', { name: 'Remove from the selection' });
+      if (await remove.isVisible()) {
+        await remove.click();
+        await expect(page.getByText('Removed from the selection.')).toBeVisible();
+      }
     }
   });
 });

--- a/fixtures/framework-e2e/src/modules/catalog/components/item-card.tsx
+++ b/fixtures/framework-e2e/src/modules/catalog/components/item-card.tsx
@@ -7,11 +7,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ItemDetail } from '@/modules/catalog/components/item-detail';
 import type { Item } from '@/modules/fixture/model';
 import { SelectionToggle } from '@/modules/selection/components/selection-toggle';
-import { toggleSelection } from '@/modules/selection/server-functions';
 
 export function ItemCard({ item }: { readonly item: Item }) {
-  const toggleSelectionAction = toggleSelection.bind(null, { itemId: item.id });
-
   return (
     <Card className='gap-0 rounded-lg py-0 shadow-none'>
       <article className='grid sm:grid-cols-[7.5rem_minmax(0,1fr)]'>
@@ -41,7 +38,7 @@ export function ItemCard({ item }: { readonly item: Item }) {
           >
             <ItemDetail detailId={item.detailId} />
           </Suspense>
-          <SelectionToggle action={toggleSelectionAction} isSelected={item.isSelected} />
+          <SelectionToggle itemId={item.id} isSelected={item.isSelected} />
         </CardContent>
       </article>
     </Card>

--- a/fixtures/framework-e2e/src/modules/fixture/components/fixture-home.tsx
+++ b/fixtures/framework-e2e/src/modules/fixture/components/fixture-home.tsx
@@ -6,13 +6,15 @@ import { buttonVariants } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ERSC } from '@/ersc';
 import { cn } from '@/lib/utils';
-import type { FixtureMetadata, ObservedQuery } from '@/modules/fixture/model';
+import type { FixtureMetadata, ObservedQuery, SelectionItem } from '@/modules/fixture/model';
 import { FixtureService } from '@/modules/fixture/service';
+import { SelectionToggle } from '@/modules/selection/components/selection-toggle';
 
 import RuntimeProbe from './runtime-probe';
 
 type FixtureHomeProps = {
   readonly fixture: ObservedQuery<FixtureMetadata>;
+  readonly selection: ObservedQuery<ReadonlyArray<SelectionItem>>;
 };
 
 const groups = [
@@ -30,7 +32,7 @@ const groups = [
   },
 ] as const;
 
-function FixtureHomeView({ fixture }: FixtureHomeProps) {
+function FixtureHomeView({ fixture, selection }: FixtureHomeProps) {
   return (
     <main className='mx-auto max-w-7xl px-5 py-12 sm:px-8 lg:py-16'>
       <header className='max-w-3xl border-b pb-9'>
@@ -54,6 +56,11 @@ function FixtureHomeView({ fixture }: FixtureHomeProps) {
       </header>
 
       <RuntimeProbe />
+      {/* Outside Suspense so native forms remain visible even without reveal scripts. */}
+      <SelectionToggle
+        itemId='service-layer'
+        isSelected={selection.data.some((item) => item.id === 'service-layer')}
+      />
       <section className='grid gap-4 py-9 sm:grid-cols-2' aria-label='Fixture route groups'>
         {groups.map((group) => (
           <Card key={group.href}>
@@ -83,7 +90,8 @@ export const FixtureHomePage = ERSC.Page.make({
   render: Effect.fn('FixtureHomePage')(function* () {
     const service = yield* FixtureService;
     const fixture = yield* service.fixture;
+    const selection = yield* service.selection;
 
-    return <FixtureHomeView fixture={fixture} />;
+    return <FixtureHomeView fixture={fixture} selection={selection} />;
   }),
 });

--- a/fixtures/framework-e2e/src/modules/selection/components/selection-toggle.tsx
+++ b/fixtures/framework-e2e/src/modules/selection/components/selection-toggle.tsx
@@ -4,19 +4,20 @@ import { Check, Plus, X } from 'lucide-react';
 import { useActionState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import type { SelectionMutationState } from '@/modules/selection/server-functions';
+import { toggleSelection } from '@/modules/selection/server-functions';
 
 type SelectionToggleProps = {
-  readonly action: () => Promise<SelectionMutationState>;
+  readonly itemId: string;
   readonly isSelected: boolean;
 };
 
-export function SelectionToggle({ action, isSelected }: SelectionToggleProps) {
-  const [state, formAction, pending] = useActionState<SelectionMutationState | null>(action, null);
+export function SelectionToggle({ itemId, isSelected }: SelectionToggleProps) {
+  const [state, formAction, pending] = useActionState(toggleSelection, null);
   const selected = state?.selected ?? isSelected;
 
   return (
     <form action={formAction} className='mt-5 flex flex-wrap items-center gap-3'>
+      <input name='itemId' type='hidden' value={itemId} />
       <Button
         aria-label={selected ? 'Remove from the selection' : 'Add to the selection'}
         disabled={pending}

--- a/fixtures/framework-e2e/src/modules/selection/server-functions.ts
+++ b/fixtures/framework-e2e/src/modules/selection/server-functions.ts
@@ -5,11 +5,12 @@ import { Effect, Schema } from 'effect';
 import { ActorERSC, CurrentActor } from '@/modules/fixture/actor';
 import { FixtureService } from '@/modules/fixture/service';
 
-export type SelectionMutationState = {
-  readonly message: string;
-  readonly selected: boolean | null;
-  readonly status: 'error' | 'success';
-};
+const SelectionMutationState = Schema.Struct({
+  message: Schema.String,
+  selected: Schema.NullOr(Schema.Boolean),
+  status: Schema.Literals(['error', 'success']),
+});
+export type SelectionMutationState = typeof SelectionMutationState.Type;
 
 type ToggleSelectionSuccess = {
   readonly _tag: 'Success';
@@ -25,8 +26,8 @@ const ToggleSelectionInput = Schema.Struct({
 });
 
 export const toggleSelection = ActorERSC.ServerFn.make({
-  input: ToggleSelectionInput,
-  handler: Effect.fn('toggleSelection')(function* ({ itemId }) {
+  input: [Schema.NullOr(SelectionMutationState), Schema.fromFormData(ToggleSelectionInput)],
+  handler: Effect.fn('toggleSelection')(function* (_previousState, { itemId }) {
     const actor = yield* CurrentActor;
     const service = yield* FixtureService;
     const outcome = yield* service.toggleSelection(itemId).pipe(

--- a/packages/effective-rsc/LLMS.md
+++ b/packages/effective-rsc/LLMS.md
@@ -75,12 +75,19 @@ Callers pass the Schema's encoded type and the handler receives its decoded type
 input; a function returning `void` can then be passed directly to `<form action>`. Let the Schema
 infer the handler parameter.
 
+For form feedback with `useActionState`, use `input: [StateSchema, FormSchema]` and
+`handler: (previousState, form) => ...`. React supplies both arguments; ERSC validates and decodes
+each one. Keep the native Server Function reference intact when passing it to `useActionState`
+to retain progressive enhancement. A single Array or Tuple Schema still describes one argument.
+
 A successful invocation refreshes the current route.
 
 - **[Creating the Server Function authoring module](./docs/02-guides/01-server-functions/10_ersc.ts)**
 - **[Defining a Server Function](./docs/02-guides/01-server-functions/20_follow-author.ts)**: ERSC decodes FormData before running the Effect handler.
 - **[Rendering a direct form action](./docs/02-guides/01-server-functions/30_follow-author-button.tsx)**: A FormData Server Function can be passed directly to form action.
 - **[Closing the Server Function application](./docs/02-guides/01-server-functions/40_application.tsx)**
+- **[Defining a stateful form action](./docs/02-guides/01-server-functions/50_greet.ts)**: A schema list decodes React's previous state and submitted FormData separately.
+- **[Rendering a stateful form](./docs/02-guides/01-server-functions/60_greeting-form.tsx)**: Pass the native reference to useActionState so React also owns progressive form submission.
 
 ## Services
 
@@ -352,6 +359,12 @@ decodes the invocation payload and infers the handler parameter; do not annotate
 returns an Effect whose requirements fit the ERSC service universe. The client reference accepts the
 Schema's encoded type and resolves `Promise<Output>`; the handler receives its decoded type.
 
+For multiple positional arguments, supply a readonly schema list as `input`. Each caller argument
+uses its Schema's encoded type; each handler argument uses its decoded type, in the same order.
+Inline lists infer their tuple shape without `as const`. Use `input: []` for no arguments.
+`input: Schema.Array(...)` and `input: Schema.Tuple(...)` still describe one argument, not a
+positional argument list.
+
 ```ts
 const followAuthor = ERSC.ServerFn.make({
   input: Schema.Struct({ authorId: Schema.NonEmptyString }),
@@ -376,6 +389,23 @@ const followAuthorForm = ERSC.ServerFn.make({
 
 A ServerFn created from a derived view activates its middleware for the POST. The Middleware
 reference defines refresh reach and ordering.
+
+For a `useActionState` form, declare both the previous state and submitted FormData:
+
+```ts
+const StateSchema = Schema.Struct({ message: Schema.String });
+const FormSchema = Schema.fromFormData(Schema.Struct({ name: Schema.NonEmptyString }));
+
+const greet = ERSC.ServerFn.make({
+  input: [StateSchema, FormSchema],
+  handler: (_previousState, { name }) => Effect.succeed({ message: `Hello, ${name}` }),
+});
+```
+
+Pass the native reference directly to `useActionState(greet, { message: '' })` and its returned
+action to `<form action>`. React supplies previous state and FormData for hydrated and progressive
+submissions. Previous state is client input: validate it, but never trust it for authorization or
+authoritative application state. Native `.bind` can prefill leading arguments.
 
 Direct server invocation throws. Encode expected failure in a discriminated output union; unexpected
 failures reject the Promise. Browser requests require an Origin matching the application host and

--- a/packages/effective-rsc/docs/02-guides/01-server-functions/50_greet.ts
+++ b/packages/effective-rsc/docs/02-guides/01-server-functions/50_greet.ts
@@ -1,0 +1,18 @@
+/**
+ * @title Defining a stateful form action
+ *
+ * A schema list decodes React's previous state and submitted FormData separately.
+ */
+'use server';
+
+import { Effect, Schema } from 'effect';
+
+import { ERSC } from './10_ersc';
+
+const StateSchema = Schema.Struct({ message: Schema.String });
+const FormSchema = Schema.fromFormData(Schema.Struct({ name: Schema.NonEmptyString }));
+
+export const greet = ERSC.ServerFn.make({
+  input: [StateSchema, FormSchema],
+  handler: (_previousState, { name }) => Effect.succeed({ message: `Hello, ${name}` }),
+});

--- a/packages/effective-rsc/docs/02-guides/01-server-functions/60_greeting-form.tsx
+++ b/packages/effective-rsc/docs/02-guides/01-server-functions/60_greeting-form.tsx
@@ -1,0 +1,23 @@
+/**
+ * @title Rendering a stateful form
+ *
+ * Pass the native reference to useActionState so React also owns progressive form submission.
+ */
+'use client';
+
+import { useActionState } from 'react';
+
+import { greet } from './50_greet';
+
+export function GreetingForm() {
+  const [state, formAction, pending] = useActionState(greet, { message: '' });
+  return (
+    <form action={formAction}>
+      <input name='name' required />
+      <button disabled={pending} type='submit'>
+        Greet
+      </button>
+      <p aria-live='polite'>{state.message}</p>
+    </form>
+  );
+}

--- a/packages/effective-rsc/docs/02-guides/01-server-functions/index.md
+++ b/packages/effective-rsc/docs/02-guides/01-server-functions/index.md
@@ -7,6 +7,11 @@ Callers pass the Schema's encoded type and the handler receives its decoded type
 input; a function returning `void` can then be passed directly to `<form action>`. Let the Schema
 infer the handler parameter.
 
+For form feedback with `useActionState`, use `input: [StateSchema, FormSchema]` and
+`handler: (previousState, form) => ...`. React supplies both arguments; ERSC validates and decodes
+each one. Keep the native Server Function reference intact when passing it to `useActionState`
+to retain progressive enhancement. A single Array or Tuple Schema still describes one argument.
+
 A successful invocation refreshes the current route.
 
 <!-- source-navigation -->
@@ -17,3 +22,5 @@ A successful invocation refreshes the current route.
 - [Define a Server Function](./20_follow-author.ts)
 - [Use a direct form action](./30_follow-author-button.tsx)
 - [Compose the application](./40_application.tsx)
+- [Define a stateful form action](./50_greet.ts)
+- [Render a stateful form](./60_greeting-form.tsx)

--- a/packages/effective-rsc/docs/04-api-reference/08-server-fn/index.md
+++ b/packages/effective-rsc/docs/04-api-reference/08-server-fn/index.md
@@ -5,6 +5,12 @@ decodes the invocation payload and infers the handler parameter; do not annotate
 returns an Effect whose requirements fit the ERSC service universe. The client reference accepts the
 Schema's encoded type and resolves `Promise<Output>`; the handler receives its decoded type.
 
+For multiple positional arguments, supply a readonly schema list as `input`. Each caller argument
+uses its Schema's encoded type; each handler argument uses its decoded type, in the same order.
+Inline lists infer their tuple shape without `as const`. Use `input: []` for no arguments.
+`input: Schema.Array(...)` and `input: Schema.Tuple(...)` still describe one argument, not a
+positional argument list.
+
 ```ts
 const followAuthor = ERSC.ServerFn.make({
   input: Schema.Struct({ authorId: Schema.NonEmptyString }),
@@ -29,6 +35,23 @@ const followAuthorForm = ERSC.ServerFn.make({
 
 A ServerFn created from a derived view activates its middleware for the POST. The Middleware
 reference defines refresh reach and ordering.
+
+For a `useActionState` form, declare both the previous state and submitted FormData:
+
+```ts
+const StateSchema = Schema.Struct({ message: Schema.String });
+const FormSchema = Schema.fromFormData(Schema.Struct({ name: Schema.NonEmptyString }));
+
+const greet = ERSC.ServerFn.make({
+  input: [StateSchema, FormSchema],
+  handler: (_previousState, { name }) => Effect.succeed({ message: `Hello, ${name}` }),
+});
+```
+
+Pass the native reference directly to `useActionState(greet, { message: '' })` and its returned
+action to `<form action>`. React supplies previous state and FormData for hydrated and progressive
+submissions. Previous state is client input: validate it, but never trust it for authorization or
+authoritative application state. Native `.bind` can prefill leading arguments.
 
 Direct server invocation throws. Encode expected failure in a discriminated output union; unexpected
 failures reject the Promise. Browser requests require an Origin matching the application host and

--- a/packages/effective-rsc/src/application/server-fn.ts
+++ b/packages/effective-rsc/src/application/server-fn.ts
@@ -1,4 +1,4 @@
-import { Effect, Predicate, Schema } from 'effect';
+import { Array, Effect, Predicate, Schema } from 'effect';
 
 import { attachERSCMember, type ERSCIdentity, type ERSCMember } from './ersc-identity';
 import type { AnyMiddleware } from './middleware';
@@ -27,26 +27,40 @@ type ServerFnInvocationMatch<ApplicationServices> =
       readonly middleware: ReadonlyArray<AnyMiddleware<ApplicationServices>>;
     };
 
-interface ServerFunction<Input, Output, ApplicationServices> extends ERSCMember<
+type ServerFnInput<Services> =
+  | Schema.ConstraintDecoder<unknown, Services>
+  | ReadonlyArray<Schema.ConstraintDecoder<unknown, Services>>;
+
+type ServerFnArguments<Input, Side extends 'Type' | 'Encoded'> =
+  Input extends ReadonlyArray<Schema.Constraint>
+    ? {
+        -readonly [Key in keyof Input]: Input[Key] extends Schema.Constraint
+          ? Input[Key][Side]
+          : never;
+      }
+    : Input extends Schema.Constraint
+      ? [Input[Side]]
+      : never;
+
+interface ServerFunction<
+  Args extends ReadonlyArray<unknown>,
+  Output,
   ApplicationServices,
-  'ServerFn'
-> {
-  (input: Input): Promise<Output>;
+> extends ERSCMember<ApplicationServices, 'ServerFn'> {
+  (...args: Args): Promise<Output>;
 }
 
-type ServerFnOptions<InputSchema extends Schema.Constraint, Output, Error, Services> = {
-  readonly input: InputSchema;
-  readonly handler: (input: InputSchema['Type']) => Effect.Effect<Output, Error, Services>;
+type ServerFnOptions<Input, Output, Error, Services> = {
+  readonly input: Input;
+  readonly handler: (
+    ...args: ServerFnArguments<Input, 'Type'>
+  ) => Effect.Effect<Output, Error, Services>;
 };
 
 export type ServerFnFactory<ApplicationServices, AvailableServices> = {
-  readonly make: <
-    InputSchema extends Schema.ConstraintDecoder<unknown, AvailableServices>,
-    Output,
-    Error,
-  >(
-    options: ServerFnOptions<InputSchema, Output, Error, AvailableServices>,
-  ) => ServerFunction<InputSchema['Encoded'], Output, ApplicationServices>;
+  readonly make: <const Input extends ServerFnInput<AvailableServices>, Output, Error>(
+    options: ServerFnOptions<Input, Output, Error, AvailableServices>,
+  ) => ServerFunction<ServerFnArguments<Input, 'Encoded'>, Output, ApplicationServices>;
 };
 
 const directInvocationError = () =>
@@ -82,10 +96,15 @@ export const makeServerFnFactory = <ApplicationServices, AvailableServices>(
   middleware: ReadonlyArray<AnyMiddleware<ApplicationServices>>,
 ): ServerFnFactory<ApplicationServices, AvailableServices> => ({
   make: ({ input, handler }) => {
-    const decode = Schema.decodeUnknownEffect(input);
-    const serverFunction = (untrustedInput: typeof input.Encoded) => {
-      const effect = decode(untrustedInput).pipe(
-        Effect.flatMap(handler),
+    const schemas = Array.ensure<Schema.ConstraintDecoder<unknown, AvailableServices>>(input);
+    const decode = Schema.decodeUnknownEffect(Schema.Tuple(schemas));
+    const serverFunction = (...untrustedArgs: ServerFnArguments<typeof input, 'Encoded'>) => {
+      // Unary functions still ignore extra native arguments and decode undefined when omitted.
+      const effect = decode(Array.isArray(input) ? untrustedArgs : [untrustedArgs[0]]).pipe(
+        // Normalization preserves the positional Type mapping, which the generic branch erases.
+        Effect.flatMap((args: ReadonlyArray<unknown>) =>
+          handler(...(args as ServerFnArguments<typeof input, 'Type'>)),
+        ),
         Effect.mapError((cause) => new ServerFnOperationError({ cause })),
       );
       const unavailable = Promise.reject<Effect.Success<typeof effect>>(directInvocationError());

--- a/packages/effective-rsc/tests/application/server-fn.test.ts
+++ b/packages/effective-rsc/tests/application/server-fn.test.ts
@@ -73,6 +73,117 @@ describe('ServerFn.make', () => {
     }),
   );
 
+  it.effect('decodes previous state and FormData with request services', () =>
+    Effect.gen(function* () {
+      const ERSC = Application.ersc<Greeting>();
+      const greet = ERSC.ServerFn.make({
+        input: [
+          Schema.FiniteFromString,
+          Schema.fromFormData(Schema.Struct({ name: Schema.NonEmptyString })),
+        ],
+        handler: Effect.fn('greet')(function* (count, { name }) {
+          const greeting = yield* Greeting;
+          return `${greeting.prefix}, ${name}: ${count + 1}`;
+        }),
+      });
+      const form = new FormData();
+      form.set('name', 'Nikhil');
+      const invocation: Promise<string> = greet('2', form);
+      const result = yield* invocationEffect(invocation, getERSCIdentity(ERSC));
+      expect(result).toBe('Hello, Nikhil: 3');
+    }).pipe(Effect.provideService(Greeting, { prefix: 'Hello' })),
+  );
+
+  it.effect('validates every positional argument before running the handler', () =>
+    Effect.gen(function* () {
+      let invoked: 'Waiting' | 'Invoked' = 'Waiting';
+      const ERSC = Application.ersc();
+      const action = ERSC.ServerFn.make({
+        input: [Schema.Finite, Schema.fromFormData(Schema.Struct({ name: Schema.NonEmptyString }))],
+        handler: () =>
+          Effect.sync(() => {
+            invoked = 'Invoked';
+          }),
+      });
+      const form = new FormData();
+      form.set('name', 'Nikhil');
+      for (const args of [['invalid state', form], [0, new FormData()], [0], []]) {
+        const invocation = Reflect.apply(action, null, args);
+        const exit = yield* Effect.exit(invocationEffect(invocation, getERSCIdentity(ERSC)));
+        expect(exit._tag).toBe('Failure');
+      }
+      expect(invoked).toBe('Waiting');
+    }),
+  );
+
+  it.effect('keeps array and tuple Schemas as single arguments', () =>
+    Effect.gen(function* () {
+      const ERSC = Application.ersc();
+      const array = ERSC.ServerFn.make({
+        input: Schema.Array(Schema.String),
+        handler: Effect.succeed,
+      });
+      const tuple = ERSC.ServerFn.make({
+        input: Schema.Tuple([Schema.String, Schema.Finite]),
+        handler: Effect.succeed,
+      });
+      const arrayResult = yield* invocationEffect(
+        array(['first', 'second']),
+        getERSCIdentity(ERSC),
+      );
+      const tupleResult = yield* invocationEffect(tuple(['first', 2]), getERSCIdentity(ERSC));
+      expect(arrayResult).toEqual(['first', 'second']);
+      expect(tupleResult).toEqual(['first', 2]);
+    }),
+  );
+
+  it.effect('preserves unary handling of omitted and extra native arguments', () =>
+    Effect.gen(function* () {
+      const ERSC = Application.ersc();
+      const action = ERSC.ServerFn.make({
+        input: Schema.Undefined,
+        handler: () => Effect.succeed('done'),
+      });
+      for (const args of [[], [undefined, 'ignored']]) {
+        const result = yield* invocationEffect(
+          Reflect.apply(action, null, args),
+          getERSCIdentity(ERSC),
+        );
+        expect(result).toBe('done');
+      }
+    }),
+  );
+
+  it.effect('retains lazy execution and positional order after binding arguments', () =>
+    Effect.gen(function* () {
+      const values: Array<string> = [];
+      const ERSC = Application.ersc();
+      const action = ERSC.ServerFn.make({
+        input: [Schema.String, Schema.Finite, Schema.String],
+        handler: (prefix, count, suffix) =>
+          Effect.sync(() => {
+            const value = `${prefix}:${count}:${suffix}`;
+            values.push(value);
+            return value;
+          }),
+      });
+      const invocation = action.bind(null, 'bound')(2, 'tail');
+      expect(values).toEqual([]);
+      const result = yield* invocationEffect(invocation, getERSCIdentity(ERSC));
+      expect(result).toBe('bound:2:tail');
+      expect(values).toEqual(['bound:2:tail']);
+    }),
+  );
+
+  it.effect('supports an empty argument list', () =>
+    Effect.gen(function* () {
+      const ERSC = Application.ersc();
+      const action = ERSC.ServerFn.make({ input: [], handler: () => Effect.succeed('done') });
+      const result = yield* invocationEffect(action(), getERSCIdentity(ERSC));
+      expect(result).toBe('done');
+    }),
+  );
+
   it.effect('rejects untrusted input before invoking the handler', () =>
     Effect.gen(function* () {
       const invoked = yield* Ref.make(false);

--- a/packages/effective-rsc/tests/types/server-fn.types.tsx
+++ b/packages/effective-rsc/tests/types/server-fn.types.tsx
@@ -1,0 +1,79 @@
+import { Context, Effect, Option, Schema } from 'effect';
+import { useActionState } from 'react';
+
+import { Application } from '../../src/application/ersc';
+
+const ERSC = Application.ersc();
+const State = Schema.Struct({ count: Schema.Finite });
+const Form = Schema.fromFormData(Schema.Struct({ name: Schema.NonEmptyString }));
+const action = ERSC.ServerFn.make({
+  input: [State, Form],
+  handler: (previousState, form) => {
+    const stateIsNotAny: 0 extends 1 & typeof previousState ? false : true = true;
+    const formIsNotAny: 0 extends 1 & typeof form ? false : true = true;
+    void stateIsNotAny;
+    void formIsNotAny;
+    const name: string = form.name;
+    void name;
+    return Effect.succeed({ count: previousState.count + 1 });
+  },
+});
+const result: Promise<{ readonly count: number }> = action({ count: 0 }, new FormData());
+void result;
+// @ts-expect-error The caller sends encoded FormData, not the decoded record.
+void action({ count: 0 }, { name: 'Nikhil' });
+// @ts-expect-error Argument order is fixed by input.
+void action(new FormData(), { count: 0 });
+// @ts-expect-error Both arguments are required.
+void action({ count: 0 });
+// @ts-expect-error The declaration has exactly two arguments.
+void action({ count: 0 }, new FormData(), 'extra');
+
+function ActionForm() {
+  const [state, formAction] = useActionState(action, { count: 0 });
+  return <form action={formAction}>{state.count}</form>;
+}
+void ActionForm;
+
+const transformed = ERSC.ServerFn.make({
+  input: [Schema.FiniteFromString, Schema.String] as const,
+  handler: Effect.fnUntraced(function* (count, text) {
+    const value: number = count;
+    return yield* Effect.succeed(`${value}:${text}`);
+  }),
+});
+const bound: (text: string) => Promise<string> = transformed.bind(null, '2');
+void bound;
+// @ts-expect-error Caller uses the encoded number string.
+void transformed(2, 'text');
+
+const tuple = ERSC.ServerFn.make({
+  input: Schema.Tuple([Schema.String, Schema.Finite]),
+  handler: Effect.succeed,
+});
+void tuple(['text', 2]);
+// @ts-expect-error A Tuple Schema still describes one argument.
+void tuple('text', 2);
+const noArgs = ERSC.ServerFn.make({ input: [], handler: () => Effect.void });
+void noArgs();
+// @ts-expect-error An empty schema list declares no arguments.
+void noArgs('extra');
+
+class DecoderService extends Context.Service<DecoderService, object>()(
+  'ersc/tests/types/server-fn/DecoderService',
+) {}
+const ServiceSchema = Schema.String.pipe(
+  Schema.catchDecodingWithContext(() => Effect.map(DecoderService, () => Option.some('fallback'))),
+);
+ERSC.ServerFn.make({
+  // @ts-expect-error Every positional decoder must fit the service universe.
+  input: [Schema.String, ServiceSchema],
+  handler: () => Effect.void,
+});
+const ProvideDecoder = ERSC.Middleware.make<{ provides: DecoderService }>((operation) =>
+  operation.pipe(Effect.provideService(DecoderService, {})),
+);
+ERSC.withMiddleware(ProvideDecoder).ServerFn.make({
+  input: [Schema.String, ServiceSchema],
+  handler: (first, second) => Effect.succeed(first + second),
+});


### PR DESCRIPTION
- Accept a single input schema or an array of positional schemas.
- Infer each handler argument from its schema.
- Update forms and guides to use positional inputs with React action state.