### PR TITLE
fix: return 404 for rejected Page parameters

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,9 +57,6 @@ Details:
 
 ## Known limitations
 
-- **L002 — Page parameter rejection:** a matched Page's Schema failure has no settled mapping to
-  NotFound or another expected HTTP outcome. See
-  [OQ-003](OPEN_QUESTIONS.md#oq-003--route-parameter-schema-rejection).
 - **L003 — Server Function failures:** the handler's typed Effect failure is not represented in the
   client Promise type. Expected failures should be encoded in the output. See
   [OQ-006](OPEN_QUESTIONS.md#oq-006--server-function-failure-channel).

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -72,6 +72,7 @@ entry; read Git history for what it said.
 | D-066 | Finish native Navigation at first UI commit. The client router retains Flight until EOF or render retirement, preserves visible UI while successors prepare, discards precommit renders before release, and uses React errors without history rollback.           |
 | D-067 | Keep React `<ViewTransition>` boundaries and styles application-owned. At publication, tag routes with additive kind, direction, and UA visual-transition types, and tag Server Function and HMR refreshes with dedicated types.                                  |
 | D-068 | Let ServerFn input be one Schema for one argument or a readonly schema list for positional arguments, including previous state and FormData for native useActionState. A Tuple or Array Schema remains a single argument. Resolves OQ-008.                        |
+| D-069 | Decode Page params once in the request handler before GET/HEAD rendering; rejection returns an empty 404, including Flight. POST keeps render-time decoding and completed Server Function outcomes. Resolves OQ-003.                                              |
 
 ## Deferred
 

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -7,16 +7,6 @@ IDs are append-only and never reused, including after a question is resolved.
 
 ## Open
 
-### OQ-003 — Route-parameter Schema rejection
-
-- **Question:** How should a matched Page's path-parameter Schema rejection map to NotFound or another expected failure?
-- **Why:** Effect HTTP has already selected the route, but the application-level Schema can still reject captured values.
-- **Affected:** Page rendering, HTTP status, error boundaries, and navigation Flight. Any non-200 answer widens `RequestOutcome['status']`, which is `200` today.
-- **Evidence:** Parameter Schemas currently fail in the Page render Effect after route selection.
-- **Related:** D-028, D-046.
-- **Resolution:** Unresolved.
-- **Status:** Open.
-
 ### OQ-004 — Typed search parameters
 
 - **Question:** How should Pages declare and decode typed search parameters?

--- a/docs/architecture/authoring.md
+++ b/docs/architecture/authoring.md
@@ -54,6 +54,12 @@ Page paths own `:parameter` segments. Mount prefixes are parameter-free. ERSC va
 paths, duplicate matcher shapes, concern identity, parameter Schema keys, and the reserved `/_ersc`
 namespace. Effect HTTP remains the only runtime matcher.
 
+On GET/HEAD, the request handler decodes the matched Page's parameters once, before
+Flight or HTML rendering begins. The Page receives those decoded values; Schema rejection returns
+an empty `404`. Decoding can use services from the application and existing route middleware and
+is interrupted with its request. Server Function POST refreshes retain parameter decoding inside
+Page rendering.
+
 Compilation flattens the graph into destinations containing the Page, middleware, and
 Layout/Loading ancestry. A graph may be mounted at several prefixes, so every destination owns its
 complete ancestry. Rendering produces one unary tree:

--- a/docs/architecture/lifetimes-and-protocols.md
+++ b/docs/architecture/lifetimes-and-protocols.md
@@ -44,6 +44,9 @@ rules.
 
 - A wiring invariant unreachable from request or application input throws a plain `TypeError`.
 - Request input, I/O, and application failures remain typed Effect failures at their boundary.
+- Page parameter Schema rejection on GET/HEAD becomes an empty `404` before rendering. Decoder
+  defects, interruption, and application render failures are not mapped to `404`. POST refresh
+  parameter rejection remains in React's render-error path, preserving the Server Function result.
 - React's stream protocol carries Flight failures.
 - If Fizz fails before the HTML shell, Effect HTTP returns an empty `500`. After headers commit,
   React and Web Streams own boundary recovery or stream termination.

--- a/docs/architecture/request-flows.md
+++ b/docs/architecture/request-flows.md
@@ -20,6 +20,11 @@ sequenceDiagram
 The browser makes no second initial Flight request. It hydrates `document`, not a framework
 container. Closing the response cancels both stream branches and interrupts request Effects.
 
+The GET/HEAD request handler validates parameters before either renderer starts, including
+when the Page is beneath Loading. Services from existing route middleware remain available during
+validation. Schema rejection returns an empty `404`; decoder defects are not classified as missing
+routes.
+
 ## Client navigation
 
 ```mermaid
@@ -50,6 +55,9 @@ fetch new Flight. A candidate leaves the current route visible until its replace
 precommit abort discards it without history rollback, while postcommit Flight failures use React's
 error handling.
 
+A navigation Flight request uses the same parameter validation boundary. Its `404` triggers the
+existing native document fallback, whose GET also receives an empty `404`.
+
 ## Server Function
 
 Hydrated calls use React's native Server Function POST. ERSC requires an Origin whose host matches
@@ -58,6 +66,9 @@ handler Effect, and starts the route refresh independently. React's decoded argu
 be an array; other decoded values are typed `400` failures before application invocation.
 The response carries the Server Function result and refreshed Flight through React's native
 protocol, allowing the result to settle without waiting for suspended route content.
+
+POST refreshes keep parameter decoding inside Page rendering. Parameter rejection therefore stays
+in React's render-error path and does not replace a completed Server Function result with a `404`.
 
 Hydrated invocations may execute concurrently. Only the latest invocation may apply its embedded
 route tree while its original history entry remains current and no navigation is active. Other

--- a/fixtures/framework-e2e/e2e/routing.spec.ts
+++ b/fixtures/framework-e2e/e2e/routing.spec.ts
@@ -45,3 +45,40 @@ test('retains the native router response for unknown paths', async ({ request })
   expect(flight.response.status()).toBe(404);
   expect(flight.body).toBe('');
 });
+
+test('returns an empty 404 when a matched Page rejects its parameters', async ({ request }) => {
+  for (const accept of ['text/html', 'text/x-component']) {
+    const response = await request.get('/catalog/invalid', { headers: { accept } });
+    expect(response.status()).toBe(404);
+    expect(await response.text()).toBe('');
+    expect(response.headers()['vary']).toContain('Accept');
+    const head = await request.head('/catalog/invalid', { headers: { accept } });
+    expect(head.status()).toBe(404);
+    expect(await head.body()).toHaveLength(0);
+  }
+});
+
+test('falls back to a native 404 document when navigation parameters are rejected', async ({
+  page,
+}) => {
+  await page.goto('/');
+  const link = page.getByRole('link', { name: 'Open the Primary catalog' });
+  await link.evaluate((element) => element.setAttribute('href', '/catalog/invalid'));
+  await page.evaluate(() => Reflect.set(window, '__ersc_previous_document__', true));
+  const flight = page.waitForResponse(
+    (response) =>
+      response.url().endsWith('/catalog/invalid') && !response.request().isNavigationRequest(),
+  );
+  const document = page.waitForResponse(
+    (response) =>
+      response.url().endsWith('/catalog/invalid') && response.request().isNavigationRequest(),
+  );
+  await link.click();
+  expect((await flight).status()).toBe(404);
+  expect((await document).status()).toBe(404);
+  await page.waitForURL('**/catalog/invalid');
+  expect(
+    await page.evaluate(() => Reflect.get(window, '__ersc_previous_document__')),
+  ).toBeUndefined();
+  await expect(page.getByRole('heading', { name: 'ERSC Framework Fixture' })).toHaveCount(0);
+});

--- a/packages/effective-rsc/LLMS.md
+++ b/packages/effective-rsc/LLMS.md
@@ -108,7 +108,11 @@ renderer's inferred service requirements.
 - Routes are immutable and belong to one ERSC identity.
 - `page(path, page)` attaches a Page; `mount(prefix, routes)` nests a route scope.
 - Mounted scopes retain their Layout and Loading ancestry.
-- Page parameter Schemas decode Effect HTTP path captures before rendering.
+- On GET/HEAD, the request handler decodes Page parameters once before rendering, with services
+  from existing route middleware available. Rejected parameters return an empty `404`, including
+  navigation Flight.
+- Server Function POST refreshes keep parameter rejection in React's render-error path, preserving
+  the completed action result.
 - Effect HTTP owns route matching; ERSC rejects duplicate shapes and invalid composition while
   building the graph.
 
@@ -282,9 +286,14 @@ services and register native Effect HTTP on the framework router.
 the Schema's encoded keys must exactly match the path parameters and accept strings. Compose the
 Page with `Routes.page`.
 
-Pages produce React output. Only an unmatched route receives a native `404`. The mapping from a
-matched Page's parameter rejection to an expected HTTP outcome remains a
-[known limitation](https://github.com/nikhilsnayak/effective-rsc/blob/main/docs/ARCHITECTURE.md#known-limitations).
+Pages produce React output. On GET/HEAD, the request handler decodes parameters once before
+rendering, with services from existing route middleware available. Rejected parameters receive
+an empty `404`, including navigation Flight requests; unmatched routes also receive native `404`
+responses. Other failures keep their existing
+error behavior.
+
+Server Function POST refreshes decode parameters inside Page rendering. A rejection follows React's
+render-error path without replacing the completed Server Function result with a `404`.
 
 ## Layout
 

--- a/packages/effective-rsc/docs/02-guides/03-routing/index.md
+++ b/packages/effective-rsc/docs/02-guides/03-routing/index.md
@@ -3,7 +3,11 @@
 - Routes are immutable and belong to one ERSC identity.
 - `page(path, page)` attaches a Page; `mount(prefix, routes)` nests a route scope.
 - Mounted scopes retain their Layout and Loading ancestry.
-- Page parameter Schemas decode Effect HTTP path captures before rendering.
+- On GET/HEAD, the request handler decodes Page parameters once before rendering, with services
+  from existing route middleware available. Rejected parameters return an empty `404`, including
+  navigation Flight.
+- Server Function POST refreshes keep parameter rejection in React's render-error path, preserving
+  the completed action result.
 - Effect HTTP owns route matching; ERSC rejects duplicate shapes and invalid composition while
   building the graph.
 

--- a/packages/effective-rsc/docs/04-api-reference/02-page/index.md
+++ b/packages/effective-rsc/docs/04-api-reference/02-page/index.md
@@ -7,6 +7,11 @@
 the Schema's encoded keys must exactly match the path parameters and accept strings. Compose the
 Page with `Routes.page`.
 
-Pages produce React output. Only an unmatched route receives a native `404`. The mapping from a
-matched Page's parameter rejection to an expected HTTP outcome remains a
-[known limitation](https://github.com/nikhilsnayak/effective-rsc/blob/main/docs/ARCHITECTURE.md#known-limitations).
+Pages produce React output. On GET/HEAD, the request handler decodes parameters once before
+rendering, with services from existing route middleware available. Rejected parameters receive
+an empty `404`, including navigation Flight requests; unmatched routes also receive native `404`
+responses. Other failures keep their existing
+error behavior.
+
+Server Function POST refreshes decode parameters inside Page rendering. A rejection follows React's
+render-error path without replacing the completed Server Function result with a `404`.

--- a/packages/effective-rsc/src/application/page.ts
+++ b/packages/effective-rsc/src/application/page.ts
@@ -64,13 +64,14 @@ export type PageConcern<
   };
 };
 
-export type PagePathParams = Readonly<Record<string, string | undefined>>;
-export type PageRuntimeProps<ParamNames extends string = string> = {
-  readonly params: Readonly<Record<ParamNames, string | undefined>>;
+export type EncodedPageParams = Readonly<Record<string, string | undefined>>;
+export type PageParams =
+  | { readonly _tag: 'Encoded'; readonly value: EncodedPageParams }
+  | { readonly _tag: 'Decoded'; readonly value: Readonly<Record<string, unknown>> };
+export type PageRuntimeProps = {
+  readonly params: PageParams;
 };
-export type PageComponent<ParamNames extends string = string> = (
-  props: PageRuntimeProps<ParamNames>,
-) => Promise<Awaited<ReactNode>>;
+export type PageComponent = (props: PageRuntimeProps) => Promise<Awaited<ReactNode>>;
 
 export type StaticPageDefinition<Services> = ERSCStatefulMember<
   Services,
@@ -87,16 +88,16 @@ export type AnyPageDefinition<Services> =
   | StaticPageDefinition<Services>
   | ParameterizedPageDefinition<Services>;
 
-export type PageImplementationState = {
+export type PageImplementationState<Services = unknown> = {
   readonly component: PageComponent;
-  readonly paramsSchema: Schema.Constraint | null;
+  readonly paramsSchema: PageParamsSchema<Services> | null;
 };
 
 class PageDefinitionImpl<
   Services,
   ParamNames extends string,
   Mode extends 'Parameterized' | 'Static',
-  ParamsSchema extends Schema.Constraint | null,
+  ParamsSchema extends PageParamsSchema<unknown> | null,
 >
   implements
     ERSCStatefulMember<Services, 'Page', PageImplementationState>,
@@ -126,14 +127,17 @@ class PageDefinitionImpl<
   }
 }
 
-export const getPageState = <Services>(
+export function getPageState<Services>(
   page: AnyPageDefinition<Services>,
-): PageImplementationState => {
+): PageImplementationState<Services>;
+// The compiled destination installs the Page's complete middleware chain before decoding.
+// As with scoped middleware, its provided services are erased from the application contract.
+export function getPageState(page: AnyPageDefinition<unknown>): PageImplementationState {
   if (!isERSCMember(page, 'Page')) {
     throw new TypeError('Page must be created with ERSC.Page.make.');
   }
   return page[ERSCStateTypeId];
-};
+}
 
 type StaticPageOptions<Error, Services> = {
   readonly params?: never;
@@ -180,7 +184,10 @@ export const makePageFactory = <ApplicationServices, AvailableServices>(
       const component: PageComponent = ({ params }) =>
         identity.renderRuntime.run(
           'Page',
-          decodeParams(params).pipe(
+          (params._tag === 'Decoded'
+            ? Effect.succeed(params.value)
+            : decodeParams(params.value)
+          ).pipe(
             Effect.flatMap((decodedParams) =>
               Effect.suspend(() => render({ params: decodedParams })),
             ),

--- a/packages/effective-rsc/src/application/route-graph.ts
+++ b/packages/effective-rsc/src/application/route-graph.ts
@@ -13,7 +13,7 @@ export type RouteScope<Services> = {
 
 export type CompiledDestination<Services> = {
   readonly middleware: ReadonlyArray<AnyMiddleware<Services>>;
-  readonly page: PageImplementationState;
+  readonly page: PageImplementationState<Services>;
   readonly pattern: AbsolutePath;
   readonly scopes: ReadonlyArray<RouteScope<Services>>;
 };

--- a/packages/effective-rsc/src/rsc/render-route-tree.tsx
+++ b/packages/effective-rsc/src/rsc/render-route-tree.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react';
 
-import type { PagePathParams } from '../application/page';
+import type { PageParams } from '../application/page';
 import type { CompiledDestination } from '../application/route-graph';
 import type { AbsolutePath } from '../application/route-path';
 import { RouteOutlet } from '../client/route-tree';
@@ -9,18 +9,18 @@ import type { RouteTreeModel } from './route-tree';
 type RenderRouteTreeOptions<Services> = {
   readonly destination: CompiledDestination<Services>;
   readonly pathname: AbsolutePath;
-  readonly pathParams: PagePathParams;
+  readonly params: PageParams;
 };
 
 export const renderRouteTree = <Services,>({
   destination,
   pathname,
-  pathParams,
+  params,
 }: RenderRouteTreeOptions<Services>): RouteTreeModel => {
   const Page = destination.page.component;
   let tree: RouteTreeModel = {
     child: null,
-    content: <Page params={pathParams} />,
+    content: <Page params={params} />,
     id: `page:${pathname}`,
   };
 

--- a/packages/effective-rsc/src/server/application.ts
+++ b/packages/effective-rsc/src/server/application.ts
@@ -1,5 +1,5 @@
 import * as BunHttpServer from '@effect/platform-bun/BunHttpServer';
-import { Effect, Layer, Option, Stream, type Types } from 'effect';
+import { Effect, Layer, Option, Schema, Stream, type Types } from 'effect';
 import type { PlatformError } from 'effect/PlatformError';
 import {
   HttpEffect,
@@ -16,7 +16,7 @@ import {
   type AnyMiddleware,
   getScopedHttpMiddleware,
 } from '../application/middleware';
-import type { PagePathParams } from '../application/page';
+import type { EncodedPageParams, PageParams } from '../application/page';
 import type { CompiledDestination } from '../application/route-graph';
 import { FrameworkAssetNamespace, isAbsolutePath } from '../application/route-path';
 import { FlightMediaType } from '../rsc/flight';
@@ -73,7 +73,7 @@ const BunServerLayer = Layer.unwrap(
   ),
 );
 
-const EmptyPathParams: PagePathParams = Object.freeze({});
+const EmptyEncodedPageParams: EncodedPageParams = Object.freeze({});
 const DynamicResponseHeaders = {
   'cache-control': 'private, no-store',
 } as const;
@@ -157,53 +157,69 @@ const httpLayer = <Services, ApplicationError>(
       );
     }
 
-    const pathParams = yield* destination.page.paramsSchema === null
-      ? Effect.succeed(EmptyPathParams)
+    const pathname = requestUrl.value.pathname;
+    const encodedParams = yield* destination.page.paramsSchema === null
+      ? Effect.succeed(EmptyEncodedPageParams)
       : HttpRouter.params;
-    const routeTree = renderRouteTree({
-      destination,
-      pathParams,
-      pathname: requestUrl.value.pathname,
-    });
-    const flightRenderer = yield* FlightRenderer;
-    const flight = yield* flightRenderer.render({
-      formState,
-      middleware,
-      renderRuntime: identity.renderRuntime,
-      routeTree,
-      serverFnResult,
-      temporaryReferences,
-    });
+    const renderResponse = Effect.fnUntraced(function* (params: PageParams) {
+      const routeTree = renderRouteTree({
+        destination,
+        params,
+        pathname,
+      });
+      const flightRenderer = yield* FlightRenderer;
+      const flight = yield* flightRenderer.render({
+        formState,
+        middleware,
+        renderRuntime: identity.renderRuntime,
+        routeTree,
+        serverFnResult,
+        temporaryReferences,
+      });
 
-    if (request.headers['accept'] === FlightMediaType) {
-      return HttpServerResponse.stream(
-        fromWebStream(flight.stream, { releaseLockOnEnd: true }).pipe(
-          Stream.ensuring(flight.release),
-        ),
-        {
-          contentType: `${FlightMediaType};charset=utf-8`,
-          headers: {
-            ...DynamicResponseHeaders,
-            'content-location': requestUrl.value.href,
+      if (request.headers['accept'] === FlightMediaType) {
+        return HttpServerResponse.stream(
+          fromWebStream(flight.stream, { releaseLockOnEnd: true }).pipe(
+            Stream.ensuring(flight.release),
+          ),
+          {
+            contentType: `${FlightMediaType};charset=utf-8`,
+            headers: {
+              ...DynamicResponseHeaders,
+              'content-location': requestUrl.value.href,
+            },
+            status,
           },
+        );
+      }
+
+      const htmlRenderer = yield* HtmlRenderer;
+      const htmlStream = yield* htmlRenderer
+        .render({ flight, formState })
+        .pipe(Effect.onError(() => flight.release));
+
+      return HttpServerResponse.stream(
+        fromWebStream(htmlStream).pipe(Stream.ensuring(flight.release)),
+        {
+          contentType: 'text/html;charset=utf-8',
+          headers: DynamicResponseHeaders,
           status,
         },
       );
+    });
+
+    if (request.method !== 'POST' && destination.page.paramsSchema !== null) {
+      return yield* Schema.decodeEffect(destination.page.paramsSchema)(encodedParams).pipe(
+        Effect.matchEffect({
+          onFailure: () =>
+            Effect.succeed(
+              HttpServerResponse.empty({ status: 404, headers: DynamicResponseHeaders }),
+            ),
+          onSuccess: (value) => renderResponse({ _tag: 'Decoded', value }),
+        }),
+      );
     }
-
-    const htmlRenderer = yield* HtmlRenderer;
-    const htmlStream = yield* htmlRenderer
-      .render({ flight, formState })
-      .pipe(Effect.onError(() => flight.release));
-
-    return HttpServerResponse.stream(
-      fromWebStream(htmlStream).pipe(Stream.ensuring(flight.release)),
-      {
-        contentType: 'text/html;charset=utf-8',
-        headers: DynamicResponseHeaders,
-        status,
-      },
-    );
+    return yield* renderResponse({ _tag: 'Encoded', value: encodedParams });
   });
 
   const executeServerFnAndRefresh = (

--- a/packages/effective-rsc/tests/application/definition.test.tsx
+++ b/packages/effective-rsc/tests/application/definition.test.tsx
@@ -7,7 +7,8 @@ import { Application } from '../../src/application/ersc';
 import {
   type AnyPageDefinition,
   getPageState,
-  type PagePathParams,
+  type EncodedPageParams,
+  type PageRuntimeProps,
 } from '../../src/application/page';
 import type { CompiledDestination } from '../../src/application/route-graph';
 import type { AbsolutePath } from '../../src/application/route-path';
@@ -45,8 +46,13 @@ const renderApplicationRoute = <Services,>(
   routes: ReadonlyArray<CompiledDestination<Services>>,
   pattern: AbsolutePath,
   pathname: AbsolutePath = pattern,
-  pathParams: PagePathParams = {},
-) => renderRouteTree({ destination: findDestination(routes, pattern), pathname, pathParams });
+  encodedParams: EncodedPageParams = {},
+) =>
+  renderRouteTree({
+    destination: findDestination(routes, pattern),
+    pathname,
+    params: { _tag: 'Encoded', value: encodedParams },
+  });
 
 const applicationRoutes = <Services, ApplicationError>(
   application: ApplicationDefinition<Services, ApplicationError>,
@@ -130,14 +136,12 @@ describe('ERSC.make', () => {
         day: 'sunday',
       }),
     );
-    const saturdayElement = asElement<{
-      readonly params: Readonly<Record<string, string | undefined>>;
-    }>(saturdayPage.content);
+    const saturdayElement = asElement<PageRuntimeProps>(saturdayPage.content);
 
     expect(applicationRoutes(App).map(({ pattern }) => pattern)).toEqual(['/schedule/:day']);
     expect(saturdayPage.id).not.toBe(sundayPage.id);
     expect(saturdayElement.type).toBe(pageComponent(DayPage));
-    expect(saturdayElement.props.params).toEqual({ day: 'saturday' });
+    expect(saturdayElement.props.params).toEqual({ _tag: 'Encoded', value: { day: 'saturday' } });
   });
 
   it('preserves Layout ancestry and places Loading below its owning Layout', () => {

--- a/packages/effective-rsc/tests/application/page.test.ts
+++ b/packages/effective-rsc/tests/application/page.test.ts
@@ -28,7 +28,7 @@ describe('ERSC.Page.make', () => {
     const ServiceFreeERSC = Application.ersc();
     const Page = ServiceFreeERSC.Page.make({ render: () => Effect.succeed(null) });
 
-    expect(() => getPageState(Page).component({ params: {} })).toThrow(
+    expect(() => getPageState(Page).component({ params: { _tag: 'Encoded', value: {} } })).toThrow(
       new TypeError('ERSC Page rendered outside its application request runtime.'),
     );
   });
@@ -47,7 +47,9 @@ describe('ERSC.Page.make', () => {
       });
       const rendered = yield* Effect.promise(() =>
         getERSCIdentity(PageComponent).renderRuntime.bind(runtime, [], () =>
-          getPageState(PageComponent).component({ params: { day: 'sunday' } }),
+          getPageState(PageComponent).component({
+            params: { _tag: 'Encoded', value: { day: 'sunday' } },
+          }),
         ),
       );
 
@@ -73,7 +75,7 @@ describe('ERSC.Page.make', () => {
 
       const rendered = yield* Effect.promise(() =>
         getERSCIdentity(App).renderRuntime.bind(runtime, [], () =>
-          getPageState(PageComponent).component({ params: {} }),
+          getPageState(PageComponent).component({ params: { _tag: 'Encoded', value: {} } }),
         ),
       );
 
@@ -100,7 +102,9 @@ describe('ERSC.Page.make', () => {
       });
       const rendered = yield* Effect.promise(() =>
         getERSCIdentity(PageComponent).renderRuntime.bind(runtime, [], () =>
-          getPageState(PageComponent).component({ params: { slug: 'opening-keynote' } }),
+          getPageState(PageComponent).component({
+            params: { _tag: 'Encoded', value: { slug: 'opening-keynote' } },
+          }),
         ),
       );
 
@@ -130,7 +134,7 @@ describe('ERSC.Page.make', () => {
       });
       const execution = getERSCIdentity(App)
         .renderRuntime.bind(runtime, [], () =>
-          getPageState(InterruptPage).component({ params: {} }),
+          getPageState(InterruptPage).component({ params: { _tag: 'Encoded', value: {} } }),
         )
         .then(
           () => 'completed' as const,

--- a/packages/effective-rsc/tests/server/page-params.test.tsx
+++ b/packages/effective-rsc/tests/server/page-params.test.tsx
@@ -1,0 +1,244 @@
+import * as BunFileSystem from '@effect/platform-bun/BunFileSystem';
+import * as BunHttpPlatform from '@effect/platform-bun/BunHttpPlatform';
+import * as BunPath from '@effect/platform-bun/BunPath';
+import { describe, expect, it, vi } from '@effect/vitest';
+import { Context, Deferred, Effect, Fiber, Layer, Schema, SchemaTransformation } from 'effect';
+import { HttpRouter, HttpServerResponse } from 'effect/unstable/http';
+import { isValidElement } from 'react';
+
+import { Application } from '../../src/application/ersc';
+import type { PageComponent, PageRuntimeProps } from '../../src/application/page';
+import { type FlightPayload, FlightMediaType, ServerFnIdHeader } from '../../src/rsc/flight';
+import { ServerConfig } from '../../src/server/server-config';
+
+let action: () => Promise<string>;
+const renderFlight = vi.fn((payload: FlightPayload) => {
+  let leaf = payload.routeTree;
+  while (leaf.child !== null) {
+    leaf = leaf.child;
+  }
+  if (!isValidElement<PageRuntimeProps>(leaf.content)) {
+    throw new TypeError('Expected the Page element.');
+  }
+  const Page = leaf.content.type as PageComponent;
+  const rendered = Page(leaf.content.props);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      return rendered
+        .then(
+          (value) => value,
+          () => 'render-error',
+        )
+        .then((page) => {
+          controller.enqueue(
+            new TextEncoder().encode(JSON.stringify({ page, result: payload.serverFnResult })),
+          );
+          controller.close();
+        });
+    },
+  });
+});
+
+vi.doMock('react-server-dom-rspack/server.node', () => ({
+  createTemporaryReferenceSet: () => ({}),
+  decodeAction: () => Promise.resolve(action),
+  decodeFormState: () => Promise.resolve(null),
+  decodeReply: () => Promise.resolve([]),
+  loadServerAction: () => action,
+  renderToReadableStream: renderFlight,
+}));
+
+const { ServerApplication } = await import('../../src/server/application');
+
+class DecoderService extends Context.Service<
+  DecoderService,
+  {
+    readonly decode: (value: string) => Effect.Effect<string>;
+  }
+>()('ersc/tests/server/page-params/DecoderService') {}
+
+class RenderFailure extends Schema.TaggedError<RenderFailure>()('RenderFailure', {}) {}
+
+const withHarness = <A, E, R>(
+  decode: (value: string) => Effect.Effect<string>,
+  use: (call: (request: Request) => Effect.Effect<Response>) => Effect.Effect<A, E, R>,
+) => {
+  renderFlight.mockClear();
+  const ERSC = Application.ersc();
+  const Middleware = ERSC.Middleware.make<{ provides: DecoderService }>((httpEffect) =>
+    httpEffect.pipe(
+      Effect.provideService(DecoderService, { decode }),
+      Effect.map(HttpServerResponse.setHeader('x-page-middleware', 'applied')),
+    ),
+  );
+  const Scoped = ERSC.withMiddleware(Middleware);
+  const Page = Scoped.Page.make({
+    params: Schema.Struct({ slug: Schema.Literals(['valid', 'render-error', 'wait']) }).pipe(
+      Schema.decodeTo(
+        Schema.Struct({ id: Schema.String }),
+        SchemaTransformation.transformOrFail({
+          decode: ({ slug }) =>
+            Effect.flatMap(DecoderService, (service) =>
+              Effect.map(service.decode(slug), (id) => ({ id })),
+            ),
+          encode: (): Effect.Effect<{ slug: 'valid' | 'render-error' | 'wait' }> =>
+            Effect.succeed({ slug: 'valid' }),
+        }),
+      ),
+    ),
+    render: ({ params }) =>
+      params.id === 'render-error' ? Effect.fail(new RenderFailure()) : Effect.succeed(params.id),
+  });
+  action = ERSC.ServerFn.make({ input: [], handler: () => Effect.succeed('action-completed') });
+  const RootLayout = ERSC.Layout.make({ render: ({ children }) => Effect.succeed(children) });
+  const Loading = ERSC.Loading.make({ render: () => <p>Loading</p> });
+  const app = ERSC.make({
+    routes: Scoped.Routes.make({ layout: RootLayout, loading: Loading }).page(
+      '/params/:slug',
+      Page,
+    ),
+  });
+  const config = Layer.succeed(
+    ServerConfig,
+    ServerConfig.of({
+      clientAssetsCacheControl: 'no-store',
+      clientAssetsRoot: '/tmp/ersc-test-assets',
+      clientBootstrapScripts: ['/_ersc/assets/main.js'],
+      clientStylesheets: [],
+      hostname: 'localhost',
+      port: 18193,
+      publicAssetsRoot: '/tmp/ersc-test-public-assets',
+    }),
+  );
+  const layer = ServerApplication.httpLayer(app).pipe(
+    Layer.provide(config),
+    Layer.provide(Layer.mergeAll(BunFileSystem.layer, BunHttpPlatform.layer, BunPath.layer)),
+  );
+  return Effect.acquireUseRelease(
+    Effect.sync(() => HttpRouter.toWebHandler(layer, { disableLogger: true })),
+    ({ handler }) => use((request) => Effect.promise(() => handler(request))),
+    ({ dispose }) => Effect.promise(dispose),
+  );
+};
+
+const request = (slug: string, method: 'GET' | 'HEAD' | 'POST', accept: string) =>
+  new Request(`http://effective-rsc.test/params/${slug}`, {
+    method,
+    headers: {
+      accept,
+      host: 'effective-rsc.test',
+      origin: 'http://effective-rsc.test',
+      [ServerFnIdHeader]: 'action',
+    },
+  });
+
+describe('Page parameter request boundary', () => {
+  it.effect(
+    'rejects invalid GET/HEAD captures before any renderer starts, including beneath Loading',
+    () =>
+      withHarness(Effect.succeed, (call) =>
+        Effect.gen(function* () {
+          for (const method of ['GET', 'HEAD'] as const) {
+            for (const accept of ['text/html', FlightMediaType]) {
+              const response = yield* call(request('invalid', method, accept));
+              expect(response.status).toBe(404);
+              const body = yield* Effect.promise(() => response.text());
+              expect(body).toBe('');
+              expect(response.headers.get('vary')).toBe('Accept');
+              expect(response.headers.get('cache-control')).toBe('private, no-store');
+              expect(response.headers.get('x-page-middleware')).toBe('applied');
+            }
+          }
+          expect(renderFlight).not.toHaveBeenCalled();
+        }),
+      ),
+  );
+
+  it.effect('decodes once with middleware services and passes transformed params to render', () => {
+    let decodes = 0;
+    return withHarness(
+      (value) =>
+        Effect.sync(() => {
+          decodes += 1;
+          return `${value}-decoded`;
+        }),
+      (call) =>
+        Effect.gen(function* () {
+          const response = yield* call(request('valid', 'GET', FlightMediaType));
+          expect(response.status).toBe(200);
+          const body = yield* Effect.promise(() => response.json());
+          expect(body).toEqual({
+            page: 'valid-decoded',
+            result: null,
+          });
+          expect(decodes).toBe(1);
+        }),
+    );
+  });
+
+  it.effect('does not turn a decoder defect into a not-found response', () =>
+    withHarness(
+      () => Effect.die(new Error('Decoder service unavailable')),
+      (call) =>
+        Effect.gen(function* () {
+          const response = yield* call(request('valid', 'GET', FlightMediaType));
+          expect(response.status).toBe(500);
+          expect(renderFlight).not.toHaveBeenCalled();
+        }),
+    ),
+  );
+
+  it.effect('leaves application render failures in Flight', () =>
+    withHarness(Effect.succeed, (call) =>
+      Effect.gen(function* () {
+        const response = yield* call(request('render-error', 'GET', FlightMediaType));
+        expect(response.status).toBe(200);
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual({
+          page: 'render-error',
+          result: null,
+        });
+      }),
+    ),
+  );
+
+  it.effect('preserves a completed POST action when refresh parameters are invalid', () =>
+    withHarness(Effect.succeed, (call) =>
+      Effect.gen(function* () {
+        const response = yield* call(request('invalid', 'POST', FlightMediaType));
+        expect(response.status).toBe(200);
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual({
+          page: 'render-error',
+          result: { _tag: 'Success', value: 'action-completed' },
+        });
+      }),
+    ),
+  );
+
+  it.effect('interrupts parameter decoding when the request is aborted', () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>();
+      const interrupted = yield* Deferred.make<void>();
+      yield* withHarness(
+        () =>
+          Deferred.succeed(started, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.onInterrupt(() => Deferred.succeed(interrupted, undefined)),
+          ),
+        (call) =>
+          Effect.gen(function* () {
+            const pending = yield* Effect.gen(function* () {
+              const signal = yield* Effect.abortSignal;
+              return yield* call(new Request(request('wait', 'GET', FlightMediaType), { signal }));
+            }).pipe(Effect.scoped, Effect.forkScoped);
+            yield* Deferred.await(started);
+            yield* Effect.yieldNow;
+            yield* Fiber.interrupt(pending);
+            yield* Deferred.await(interrupted);
+            expect(renderFlight).not.toHaveBeenCalled();
+          }),
+      );
+    }),
+  );
+});


### PR DESCRIPTION
- Return an empty 404 for GET and HEAD when Page parameter validation fails.
- Decode parameters once within the existing route middleware.
- Preserve POST refresh behavior.
- Add request and browser regression tests.