### PR TITLE
chore(release): bump packages to 0.1.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/create-ersc-app": {
       "name": "create-ersc-app",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "create-ersc-app": "./dist/cli.js",
       },
@@ -100,7 +100,7 @@
     },
     "packages/effective-rsc": {
       "name": "effective-rsc",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "ersc": "./bin/ersc.js",
       },

--- a/packages/create-ersc-app/package.json
+++ b/packages/create-ersc-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ersc-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Scaffold an effective-rsc application with Bun",
   "keywords": [
     "bun",

--- a/packages/create-ersc-app/template/package.json
+++ b/packages/create-ersc-app/template/package.json
@@ -13,7 +13,7 @@
     "@effect/platform-browser": "4.0.0-rc.112",
     "@effect/platform-bun": "4.0.0-rc.112",
     "effect": "4.0.0-rc.112",
-    "effective-rsc": "0.1.0",
+    "effective-rsc": "0.1.1",
     "react": "19.3.0-canary-8425b691-20260904",
     "react-dom": "19.3.0-canary-8425b691-20260904",
     "react-server-dom-rspack": "0.1.0"

--- a/packages/effective-rsc/package.json
+++ b/packages/effective-rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effective-rsc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An experimental, Effect-native React Server Components framework for Bun.",
   "keywords": [
     "bun",


### PR DESCRIPTION
Bump effective-rsc and create-ersc-app to 0.1.1. Update the starter template to use effective-rsc 0.1.1 and refresh the lockfile.