### PR TITLE
chore(release): prepare 0.1.2 and allow maintenance releases

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/create-ersc-app": {
       "name": "create-ersc-app",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "create-ersc-app": "./dist/cli.js",
       },
@@ -100,7 +100,7 @@
     },
     "packages/effective-rsc": {
       "name": "effective-rsc",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "ersc": "./bin/ersc.js",
       },

--- a/packages/create-ersc-app/package.json
+++ b/packages/create-ersc-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ersc-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Scaffold an effective-rsc application with Bun",
   "keywords": [
     "bun",

--- a/packages/create-ersc-app/template/package.json
+++ b/packages/create-ersc-app/template/package.json
@@ -13,7 +13,7 @@
     "@effect/platform-browser": "4.0.0-rc.112",
     "@effect/platform-bun": "4.0.0-rc.112",
     "effect": "4.0.0-rc.112",
-    "effective-rsc": "0.1.1",
+    "effective-rsc": "0.1.2",
     "react": "19.3.0-canary-8425b691-20260904",
     "react-dom": "19.3.0-canary-8425b691-20260904",
     "react-server-dom-rspack": "0.1.0"

--- a/packages/effective-rsc/package.json
+++ b/packages/effective-rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effective-rsc",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An experimental, Effect-native React Server Components framework for Bun.",
   "keywords": [
     "bun",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,8 +14,16 @@ fi
 tag="v$version"
 branch="$(git branch --show-current)"
 if [[ "$branch" != "main" ]]; then
-  echo "Release must run from main; currently on $branch." >&2
-  exit 1
+  if [[ ! "$branch" =~ ^([0-9]+\.[0-9]+)\.x$ ]]; then
+    echo "Release must run from main or a maintenance branch such as 0.1.x; currently on $branch." >&2
+    exit 1
+  fi
+
+  maintenance_version="${BASH_REMATCH[1]}"
+  if [[ "$version" != "$maintenance_version."* ]]; then
+    echo "Release $version does not belong to maintenance branch $branch." >&2
+    exit 1
+  fi
 fi
 
 if [[ -n "$(git status --porcelain)" ]]; then
@@ -23,10 +31,10 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
-git fetch origin main --tags
+git fetch origin "$branch" --tags
 
-if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
-  echo "Local main must exactly match origin/main." >&2
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/$branch")" ]]; then
+  echo "Local $branch must exactly match origin/$branch." >&2
   exit 1
 fi
 


### PR DESCRIPTION
Bump effective-rsc and create-ersc-app to 0.1.2, including the starter template and lockfile.

Allow releases from matching maintenance branches such as 0.1.x. Preserve clean-worktree, matching-remote, and existing-tag checks.

The release-script checks passed 11 targeted cases.