### PR TITLE
fix(ssr): preserve useId paths when registering stylesheets

### DIFF
--- a/docs/architecture/request-flows.md
+++ b/docs/architecture/request-flows.md
@@ -20,6 +20,9 @@ sequenceDiagram
 The browser makes no second initial Flight request. It hydrates `document`, not a framework
 container. Closing the response cancels both stream branches and interrupts request Effects.
 
+SSR registers compiler stylesheets with React DOM's `preinit` while rendering. It does not add
+server-only siblings around the route tree, which would change React's `useId` paths during hydration.
+
 Hydration and Server Function setup also run when client-navigation APIs are missing. In that case,
 links load complete documents while Server Functions and HMR can still refresh the current page
 through Flight. Without JavaScript, forms retain the native progressive submission path.

--- a/fixtures/framework-e2e/e2e/assets.spec.ts
+++ b/fixtures/framework-e2e/e2e/assets.spec.ts
@@ -3,6 +3,31 @@ import { expect, test, type Response } from '@playwright/test';
 
 import { getText } from './support/http';
 
+test('preserves useId associations through hydration and a client update', async ({ page }) => {
+  const errors: Array<string> = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      errors.push(message.text());
+    }
+  });
+  page.on('pageerror', (error) => errors.push(error.message));
+
+  await page.goto('/');
+  const description = page.getByText('Runtime probe original', { exact: true });
+  const descriptionId = await description.getAttribute('id');
+  if (descriptionId === null) {
+    throw new Error('Missing server-rendered useId.');
+  }
+  const button = page.getByRole('button', { name: 'Probe count: 0' });
+  await expect(button).toHaveAttribute('aria-describedby', descriptionId);
+  await button.click();
+  await expect(page.getByRole('button', { name: 'Probe count: 1' })).toHaveAttribute(
+    'aria-describedby',
+    descriptionId,
+  );
+  expect(errors).toEqual([]);
+});
+
 test('loads every compiler asset needed by the hydrated document', async ({ page }, testInfo) => {
   const assetResponses: Array<Response> = [];
   page.on('response', (response) => {

--- a/fixtures/framework-e2e/src/modules/fixture/components/runtime-probe.tsx
+++ b/fixtures/framework-e2e/src/modules/fixture/components/runtime-probe.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
 export default function RuntimeProbe() {
+  const descriptionId = useId();
   const [count, setCount] = useState(0);
   const [phase, setPhase] = useState<'Ready' | 'Failed'>('Ready');
 
@@ -12,8 +13,12 @@ export default function RuntimeProbe() {
 
   return (
     <section aria-label='Runtime recovery probe'>
-      <p>Runtime probe original</p>
-      <button onClick={() => setCount((value) => value + 1)} type='button'>
+      <p id={descriptionId}>Runtime probe original</p>
+      <button
+        aria-describedby={descriptionId}
+        onClick={() => setCount((value) => value + 1)}
+        type='button'
+      >
         Probe count: {count}
       </button>
       <button onClick={() => setPhase('Failed')} type='button'>

--- a/packages/effective-rsc/src/server/html-renderer.tsx
+++ b/packages/effective-rsc/src/server/html-renderer.tsx
@@ -1,5 +1,6 @@
 import { Context, Effect, FiberSet, Layer, Schema, type Scope } from 'effect';
 import { use } from 'react';
+import { preinit } from 'react-dom';
 import { renderToReadableStream } from 'react-dom/server.bun';
 import { createFromReadableStream } from 'react-server-dom-rspack/client';
 
@@ -36,6 +37,10 @@ export class HtmlRenderer extends Context.Service<HtmlRenderer>()(
           let payload: PromiseLike<FlightPayload> | null = null;
 
           function SsrRoot() {
+            // Emit CSS without server-only siblings that shift hydration's useId paths.
+            for (const href of clientStylesheets) {
+              preinit(href, { as: 'style', precedence: 'default' });
+            }
             const { routeTree } = use(
               (payload ??= createFromReadableStream<FlightPayload>(ssrFlightStream)),
             );
@@ -44,26 +49,18 @@ export class HtmlRenderer extends Context.Service<HtmlRenderer>()(
 
           const htmlStream = yield* Effect.tryPromise({
             try: () =>
-              renderToReadableStream(
-                <>
-                  {clientStylesheets.map((href) => (
-                    <link key={href} rel='stylesheet' href={href} precedence='default' />
-                  ))}
-                  <SsrRoot />
-                </>,
-                {
-                  bootstrapScripts: [...clientBootstrapScripts],
-                  formState,
-                  onError: (error, errorInfo) => {
-                    if (!signal.aborted && !flight.signal.aborted) {
-                      void runtime(
-                        Effect.logError('HTML render failed.', error, errorInfo.componentStack),
-                      );
-                    }
-                  },
-                  signal,
+              renderToReadableStream(<SsrRoot />, {
+                bootstrapScripts: [...clientBootstrapScripts],
+                formState,
+                onError: (error, errorInfo) => {
+                  if (!signal.aborted && !flight.signal.aborted) {
+                    void runtime(
+                      Effect.logError('HTML render failed.', error, errorInfo.componentStack),
+                    );
+                  }
                 },
-              ),
+                signal,
+              }),
             catch: (cause) => new HtmlRenderError({ cause }),
           });
 

--- a/packages/effective-rsc/tests/server/html-renderer.test.ts
+++ b/packages/effective-rsc/tests/server/html-renderer.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from '@effect/vitest';
 import { Effect, Exit, Layer, Logger, Scope } from 'effect';
-import { Children, Fragment, isValidElement, type ReactNode } from 'react';
+import { isValidElement, type ReactNode } from 'react';
 import type { ReactFormState } from 'react-dom/client';
 import type { RenderToReadableStreamOptions } from 'react-dom/server';
 
@@ -53,6 +53,7 @@ vi.doMock('react-dom/server.bun', () => ({
   renderToReadableStream: renderDocument,
 }));
 const { HtmlRenderError, HtmlRenderer } = await import('../../src/server/html-renderer');
+const fizz = await vi.importActual<typeof import('react-dom/server.bun')>('react-dom/server.bun');
 const FlightHtmlInjectorTestLayer = FlightHtmlInjector.layerTest({ inject: injectPayload });
 const HtmlRendererTestLayer = HtmlRenderer.layer.pipe(
   Layer.provide(FlightHtmlInjectorTestLayer),
@@ -68,6 +69,24 @@ beforeEach(() => {
 });
 
 describe('HtmlRenderer', () => {
+  it.effect('emits compiler stylesheets through the native Fizz resource API', () =>
+    Effect.gen(function* () {
+      renderDocument.mockImplementationOnce((root, options) =>
+        fizz.renderToReadableStream(root, options),
+      );
+      const renderer = yield* HtmlRenderer;
+      const signal = yield* Effect.abortSignal;
+      const stream = yield* renderer.render({
+        flight: makeFlightRender(signal),
+        formState: null,
+      });
+      const html = yield* Effect.promise(() => new Response(stream).text());
+      expect(html).toContain(
+        'rel="stylesheet" href="/_ersc/assets/main.css" data-precedence="default"',
+      );
+    }).pipe(Effect.provide(HtmlRendererTestLayer)),
+  );
+
   it.effect('passes the request form state to Fizz without eagerly decoding Flight', () => {
     const logs: Array<unknown> = [];
     const logged = Promise.withResolvers<void>();
@@ -97,16 +116,8 @@ describe('HtmlRenderer', () => {
         return;
       }
 
-      expect(renderedRoot.type).toBe(Fragment);
-      const resources = Children.toArray(renderedRoot.props.children);
-      expect(resources[0]).toMatchObject({
-        props: {
-          href: '/_ersc/assets/main.css',
-          precedence: 'default',
-          rel: 'stylesheet',
-        },
-        type: 'link',
-      });
+      expect(typeof renderedRoot.type).toBe('function');
+      expect(renderedRoot.props.children).toBeUndefined();
       expect(renderOptions?.bootstrapScripts).toEqual(clientBootstrapScripts);
       expect(renderOptions?.formState).toBe(formState);
       expect(injectPayload).toHaveBeenCalledWith(expect.any(ReadableStream));


### PR DESCRIPTION
Register compiler stylesheets with React DOM preinit without adding server-only siblings. Add SSR and browser regressions for stable useId hydration.

Validation: root check, test, and build pass; focused renderer tests pass.