### PR TITLE
feat(vercel): package Bun deployments and add hello-world example

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,25 @@
         "vitest": "catalog:",
       },
     },
+    "examples/hello-world": {
+      "name": "@effective-rsc/example-hello-world",
+      "version": "0.0.0",
+      "dependencies": {
+        "@effect/platform-browser": "catalog:",
+        "@effect/platform-bun": "catalog:",
+        "effect": "catalog:",
+        "effective-rsc": "workspace:*",
+        "react": "catalog:",
+        "react-dom": "catalog:",
+        "react-server-dom-rspack": "catalog:",
+      },
+      "devDependencies": {
+        "@ersc/vercel": "workspace:*",
+        "@types/bun": "catalog:",
+        "@types/react": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "fixtures/framework-e2e": {
       "name": "@effective-rsc/framework-e2e",
       "version": "0.0.0",
@@ -136,6 +155,28 @@
         "react-server-dom-rspack": "catalog:",
       },
     },
+    "packages/vercel": {
+      "name": "@ersc/vercel",
+      "version": "0.0.0",
+      "dependencies": {
+        "@vercel/nft": "1.11.0",
+      },
+      "devDependencies": {
+        "@effect/platform-bun": "catalog:",
+        "@effect/vitest": "catalog:",
+        "@rslib/core": "catalog:",
+        "@types/bun": "catalog:",
+        "effect": "catalog:",
+        "effective-rsc": "workspace:*",
+        "typescript": "catalog:",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "@effect/platform-bun": "catalog:",
+        "effect": "catalog:",
+        "effective-rsc": "workspace:*",
+      },
+    },
   },
   "catalog": {
     "@base-ui/react": "^1.8.0",
@@ -217,6 +258,8 @@
 
     "@effective-rsc/example-event-platform": ["@effective-rsc/example-event-platform@workspace:examples/event-platform"],
 
+    "@effective-rsc/example-hello-world": ["@effective-rsc/example-hello-world@workspace:examples/hello-world"],
+
     "@effective-rsc/framework-e2e": ["@effective-rsc/framework-e2e@workspace:fixtures/framework-e2e"],
 
     "@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" } }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
@@ -225,6 +268,8 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g=="],
 
+    "@ersc/vercel": ["@ersc/vercel@workspace:packages/vercel"],
+
     "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
 
     "@floating-ui/dom": ["@floating-ui/dom@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.8.0", "@floating-ui/utils": "^0.2.12" } }, "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg=="],
@@ -232,6 +277,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -242,6 +289,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.3", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -380,6 +429,8 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.5", "", { "os": "win32", "cpu": "x64" }, "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
 
     "@rsbuild/core": ["@rsbuild/core@2.2.3", "", { "dependencies": { "@rspack/core": "~2.2.2", "@swc/helpers": "^0.5.23" }, "peerDependencies": { "core-js": ">= 3.0.0" }, "optionalPeers": ["core-js"], "bin": { "rsbuild": "./bin/rsbuild.js" } }, "sha512-oJrYtYDhb7AMwY8HIda2hgMuuxHkYPYar4svdS5uTq0fXY0M1wLfllkTQz0d729pNJ4S//6GUM1WX5LsW2mFLw=="],
 
@@ -527,6 +578,8 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
+    "@vercel/nft": ["@vercel/nft@1.11.0", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "@rollup/pluginutils": "^5.1.3", "acorn": "^8.6.0", "acorn-import-attributes": "^1.9.5", "async-sema": "^3.1.1", "bindings": "^1.4.0", "estree-walker": "2.0.2", "glob": "^13.0.0", "graceful-fs": "^4.2.9", "node-gyp-build": "^4.2.2", "picomatch": "^4.0.4", "resolve-from": "^5.0.0" }, "bin": { "nft": "out/cli.js" } }, "sha512-m1QFg+U+3yPOnP1xSYJ73UIRxLOXdts1JOhiOiyPYqEsALgrXFFINvgUaD6R6iNvaBFAjHllBCbkfx4FuOdpaA=="],
+
     "@vitest/expect": ["@vitest/expect@4.1.11", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.1.11", "", { "dependencies": { "@vitest/spy": "4.1.11", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ=="],
@@ -541,17 +594,35 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ=="],
 
+    "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
+
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
+
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "async-sema": ["async-sema@3.1.1", "", {}, "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
     "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -563,11 +634,15 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "create-ersc-app": ["create-ersc-app@workspace:packages/create-ersc-app"],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
@@ -585,7 +660,7 @@
 
     "es-module-lexer": ["es-module-lexer@2.3.2", "", {}, "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw=="],
 
-    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
@@ -593,13 +668,19 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
@@ -631,9 +712,19 @@
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
     "lucide-react": ["lucide-react@1.41.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-6lksP35l6KszDKUeRTi4LV7i6DEe0Yzl2ALJm9j4c5xEYN91GdW1xGsawGMOg2mgjF5GHBVX8pKX9kP+cWsP3Q=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msgpackr": ["msgpackr@2.0.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA=="],
 
@@ -641,7 +732,13 @@
 
     "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
+
+    "nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
 
     "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
@@ -658,6 +755,8 @@
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -691,11 +790,15 @@
 
     "reselect": ["reselect@5.3.0", "", {}, "sha512-XGoLeRAVzUTcJ1qkxPQhDJyIZ5d6zzZD9nT7AEZOaaU9UbWclhycElmhO+VD5bFeLuzhPBaOV2oXC8uG35ZSpg=="],
 
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
     "rolldown": ["rolldown@1.2.5", "", { "dependencies": { "@oxc-project/types": "=0.146.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm-eabi": "1.2.5", "@rolldown/binding-android-arm64": "1.2.5", "@rolldown/binding-darwin-arm64": "1.2.5", "@rolldown/binding-darwin-x64": "1.2.5", "@rolldown/binding-freebsd-x64": "1.2.5", "@rolldown/binding-linux-arm-gnueabihf": "1.2.5", "@rolldown/binding-linux-arm64-gnu": "1.2.5", "@rolldown/binding-linux-arm64-musl": "1.2.5", "@rolldown/binding-linux-ppc64-gnu": "1.2.5", "@rolldown/binding-linux-s390x-gnu": "1.2.5", "@rolldown/binding-linux-x64-gnu": "1.2.5", "@rolldown/binding-linux-x64-musl": "1.2.5", "@rolldown/binding-openharmony-arm64": "1.2.5", "@rolldown/binding-win32-arm64-msvc": "1.2.5", "@rolldown/binding-win32-x64-msvc": "1.2.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA=="],
 
     "rsbuild-plugin-dts": ["rsbuild-plugin-dts@1.0.0", "", { "dependencies": { "@ast-grep/napi": "0.45.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7", "@rsbuild/core": "^2.0.0", "typescript": "^5 || ^6 || ^7" }, "optionalPeers": ["@microsoft/api-extractor", "typescript"] }, "sha512-FVoTsiTfSc0LPeSjrVhpvFOBRig0YXJq3Hp+bVxzh9/bzFvODzLRWOEux8q1Phe1oVCIIVSc2+Nb7kDcxIhosw=="],
 
     "scheduler": ["scheduler@0.28.0-canary-8425b691-20260904", "", {}, "sha512-Obhceqy2GPLZ6wjLRv4qCcaOUCs7UjDE5D+XvjduHsOmOOrgzTMNcVYcwnElZaKzJg4iXW+ISVOs/8tqHh5bOg=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
 
@@ -717,6 +820,8 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
+    "tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
@@ -726,6 +831,8 @@
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -741,6 +848,10 @@
 
     "vitest": ["vitest@4.1.11", "", { "dependencies": { "@vitest/expect": "4.1.11", "@vitest/mocker": "4.1.11", "@vitest/pretty-format": "4.1.11", "@vitest/runner": "4.1.11", "@vitest/snapshot": "4.1.11", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.11", "@vitest/browser-preview": "4.1.11", "@vitest/browser-webdriverio": "4.1.11", "@vitest/coverage-istanbul": "4.1.11", "@vitest/coverage-v8": "4.1.11", "@vitest/ui": "4.1.11", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw=="],
 
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
@@ -750,6 +861,8 @@
     "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
@@ -780,6 +893,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "lucide-react/react": ["react@19.3.0-canary-eb8feb71-20260814", "", {}, "sha512-4CF6VVbInQ54749LzFJ6POm1SREXQmNZ6yFjTq67yCL3NrYlK+aO6nzO3i1Fe7szu/fXUr3NRzitdHj+l/O5EQ=="],
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,7 +50,8 @@ Details:
   Other runtime and build modules remain private.
 - `src/application.tsx` is the only application filename with framework semantics.
 - Generated application artifacts live under `.ersc/` and are consumed only through their generated
-  entry points. Build hooks may package their supplied output directories without modifying them.
+  entry points. Build hooks may package their supplied output directories without modifying them;
+  the separate `@ersc/vercel` package owns `.vercel/output/`.
 - React owns the RSC and Server Function protocols. ERSC adds Effect typing, validation, and
   lifetimes without replacing those transports.
 - Applications own React `<ViewTransition>` boundaries and animation policy. ERSC publishes UI in
@@ -68,6 +69,8 @@ Details:
 
 ## Examples and integration fixture
 
+[`examples/hello-world`](../examples/hello-world) is the introductory example for streaming,
+hydration, navigation, and Server Functions. It is also the Bun deployment example for Vercel.
 [`examples/event-platform`](../examples/event-platform) is the real-world product example.
 [`fixtures/framework-e2e`](../fixtures/framework-e2e) is the neutral framework integration fixture;
 its routes, data, artificial latency, and UI exist to expose protocol and lifecycle behavior.

--- a/docs/architecture/build.md
+++ b/docs/architecture/build.md
@@ -52,6 +52,24 @@ There is no autodetection, installation, or upload. Omitting the flag leaves pri
 inputs as read-only and provide their dependencies; core owns scope/cancellation. Adapter code
 is trusted. Compilation and packaging report separately; success follows scoped cleanup.
 
+### Vercel package
+
+`@ersc/vercel` generates `.vercel/output/` with one Bun 1.4 function using the existing router.
+Its entry sets the application cwd before importing `effective-rsc/server`. It traces every server
+JavaScript chunk with Bun/Node/native-addon conditions, widening the trace root for hoisted
+dependencies. Tracing failures preserve prior output; packaging does not modify `.ersc/`.
+
+Traced dependency symlinks are relocated; client/public asset symlinks are materialized.
+Broken, cyclic, or destination-containing asset links fail. Everything linked from `public/`
+is public. Computed file reads may escape tracing; local databases are not made persistent.
+Vercel project settings and deployment remain separate setup; see [the adapter README](../../packages/vercel/README.md).
+
+## Releases
+
+`bun run release <version>` checks aligned framework, adapter, CLI, and template versions,
+runs verification and package dry runs, then asks before publishing and pushing the release tag.
+GitHub creates a draft release.
+
 ## Development
 
 `ersc dev` watches the same browser and server compiler graphs. A replacement generation is fully

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,20 @@
+# Hello world
+
+Two routes, streaming, a client counter, and a Server Function form.
+
+From the repository root:
+
+```sh
+bun install --frozen-lockfile
+bun run build --filter=@effective-rsc/example-hello-world
+bun run --cwd examples/hello-world dev
+```
+
+Open `http://localhost:18214`. For production, stop dev and run
+`bun run --cwd examples/hello-world start`. Its `server.ts` uses `effective-rsc/server`.
+
+Client navigation preserves the layout counter; full-page loads reset it. The greeting form also
+works without JavaScript. Browser coverage lives in the framework fixture.
+
+The build includes `@ersc/vercel` packaging. To deploy, run `vercel deploy --prebuilt` from the
+linked example directory after building.

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@effective-rsc/example-hello-world",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "ersc dev --port 18214",
+    "build": "ersc build --adapter @ersc/vercel",
+    "start": "bun server.ts"
+  },
+  "dependencies": {
+    "@effect/platform-browser": "catalog:",
+    "@effect/platform-bun": "catalog:",
+    "effect": "catalog:",
+    "effective-rsc": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-server-dom-rspack": "catalog:"
+  },
+  "devDependencies": {
+    "@ersc/vercel": "workspace:*",
+    "@types/bun": "catalog:",
+    "@types/react": "catalog:",
+    "typescript": "catalog:"
+  },
+  "engines": {
+    "bun": ">=1.4.0"
+  }
+}

--- a/examples/hello-world/public/favicon.svg
+++ b/examples/hello-world/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#14131A" />
+  <g transform="translate(32 32) scale(0.72) translate(-32 -32)">
+    <rect x="16" y="27.5" width="26" height="9" rx="4.5" fill="#A18CFF" />
+    <rect x="16" y="11" width="9" height="42" rx="4.5" fill="#F7F5F1" />
+    <rect x="16" y="11" width="32" height="9" rx="4.5" fill="#F7F5F1" />
+    <rect x="16" y="44" width="32" height="9" rx="4.5" fill="#F7F5F1" />
+  </g>
+</svg>

--- a/examples/hello-world/server.ts
+++ b/examples/hello-world/server.ts
@@ -1,0 +1,7 @@
+import { start } from 'effective-rsc/server';
+
+await start({
+  hostname: 'localhost',
+  port: 18214,
+  root: import.meta.dir,
+});

--- a/examples/hello-world/src/application.tsx
+++ b/examples/hello-world/src/application.tsx
@@ -1,0 +1,93 @@
+import { Effect } from 'effect';
+import { Suspense } from 'react';
+
+import { Counter } from './counter';
+import { ERSC } from './ersc';
+import { GreetingForm } from './greeting-form';
+
+import './styles.css';
+
+const RootLayout = ERSC.Layout.make({
+  render: ({ children }) =>
+    Effect.succeed(
+      <html lang='en'>
+        <head>
+          <title>Hello world · effective-rsc</title>
+          <meta name='viewport' content='width=device-width, initial-scale=1' />
+          <meta
+            name='description'
+            content='An effective-rsc example with streaming and Server Functions.'
+          />
+          <link rel='icon' href='/favicon.svg' type='image/svg+xml' />
+        </head>
+        <body>
+          <div className='shell'>
+            <header>
+              <a className='brand' href='/'>
+                <img src='/favicon.svg' alt='' width={28} height={28} />
+                effective-rsc
+              </a>
+              <nav aria-label='Main navigation'>
+                <a href='/'>Home</a>
+                <a href='/about'>About</a>
+              </nav>
+            </header>
+            <main>{children}</main>
+            <aside aria-label='Client counter' className='card'>
+              <h2>Client state</h2>
+              <p>Increment the counter, then visit About. The shared layout keeps its state.</p>
+              <Counter />
+            </aside>
+            <footer>Built with effective-rsc</footer>
+          </div>
+        </body>
+      </html>,
+    ),
+});
+
+const StreamedMessage = ERSC.Component.make({
+  render: () =>
+    Effect.sleep('1 second').pipe(
+      Effect.as(<p className='response'>Rendered on the server after a one-second delay.</p>),
+    ),
+});
+
+const HomePage = ERSC.Page.make({
+  render: () =>
+    Effect.succeed(
+      <>
+        <h1>Hello world</h1>
+        <p>Server rendering, streaming, and client state in one example.</p>
+        <section className='card'>
+          <h2>Server Function</h2>
+          <p>Submit a name to generate a greeting on the server.</p>
+          <GreetingForm />
+        </section>
+        <section className='card'>
+          <h2>Streaming</h2>
+          <Suspense fallback={<output className='response'>Loading server content…</output>}>
+            <StreamedMessage />
+          </Suspense>
+        </section>
+      </>,
+    ),
+});
+
+const AboutPage = ERSC.Page.make({
+  render: () =>
+    Effect.succeed(
+      <>
+        <h1>About this example</h1>
+        <p>Both routes share a layout. Navigating between them preserves the counter below.</p>
+        <p>
+          The home page uses Suspense to stream server content and a Server Function to handle form
+          submissions. The form also works without JavaScript.
+        </p>
+        <a href='/'>Back to home</a>
+      </>,
+    ),
+});
+
+export default ERSC.make({
+  routes: ERSC.Routes.make({ layout: RootLayout }).page('/', HomePage).page('/about', AboutPage),
+});

--- a/examples/hello-world/src/counter.tsx
+++ b/examples/hello-world/src/counter.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useState } from 'react';
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <button onClick={() => setCount((current) => current + 1)} type='button'>
+      Count: {count}
+    </button>
+  );
+}

--- a/examples/hello-world/src/environment.d.ts
+++ b/examples/hello-world/src/environment.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css' {}

--- a/examples/hello-world/src/ersc.ts
+++ b/examples/hello-world/src/ersc.ts
@@ -1,0 +1,3 @@
+import { Application } from 'effective-rsc';
+
+export const ERSC = Application.ersc();

--- a/examples/hello-world/src/greet.ts
+++ b/examples/hello-world/src/greet.ts
@@ -1,0 +1,14 @@
+'use server';
+
+import { Effect, Schema } from 'effect';
+
+import { ERSC } from './ersc';
+
+const FormSchema = Schema.fromFormData(
+  Schema.Struct({ name: Schema.NonEmptyString.check(Schema.isMaxLength(80)) }),
+);
+
+export const greet = ERSC.ServerFn.make({
+  input: [Schema.String, FormSchema],
+  handler: (_previousState, { name }) => Effect.succeed(`Hello, ${name}!`),
+});

--- a/examples/hello-world/src/greeting-form.tsx
+++ b/examples/hello-world/src/greeting-form.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useActionState } from 'react';
+
+import { greet } from './greet';
+
+export function GreetingForm() {
+  const [message, formAction, pending] = useActionState(greet, '');
+
+  return (
+    <form action={formAction}>
+      <label htmlFor='name'>Name</label>
+      <div className='form-row'>
+        <input autoComplete='name' id='name' maxLength={80} name='name' required type='text' />
+        <button disabled={pending} type='submit'>
+          {pending ? 'Submitting…' : 'Submit'}
+        </button>
+      </div>
+      <p aria-live='polite' className='response'>
+        {message}
+      </p>
+    </form>
+  );
+}

--- a/examples/hello-world/src/styles.css
+++ b/examples/hello-world/src/styles.css
@@ -1,0 +1,140 @@
+:root {
+  --paper: #f7f5f1;
+  --ink: #14131a;
+  --muted: #56535f;
+  --accent: #5b3ff0;
+  --border: #dedbe5;
+  color-scheme: light dark;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  color: var(--ink);
+  background: var(--paper);
+  line-height: 1.6;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --paper: #0e0e15;
+    --ink: #f2f0f6;
+    --muted: #a5a1b2;
+    --accent: #a18cff;
+    --border: #302d3b;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.shell {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+header,
+nav,
+.brand,
+.form-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+header {
+  justify-content: space-between;
+  margin-bottom: 64px;
+}
+
+a {
+  color: var(--accent);
+  text-underline-offset: 4px;
+}
+
+.brand {
+  gap: 10px;
+  color: var(--ink);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+p {
+  color: var(--muted);
+}
+
+h1 {
+  font-size: clamp(2rem, 7vw, 3rem);
+  letter-spacing: -0.04em;
+  line-height: 1.15;
+  font-weight: 600;
+}
+
+h2 {
+  margin-top: 0;
+  font-size: 1.15rem;
+}
+
+.card {
+  margin-top: 24px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+label {
+  display: block;
+  margin-bottom: 8px;
+}
+
+button,
+input {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 14px;
+  font: inherit;
+}
+
+input {
+  background: var(--paper);
+  color: var(--ink);
+  min-width: 0;
+  width: 100%;
+  flex: 1 1 180px;
+}
+
+button {
+  background: var(--ink);
+  color: var(--paper);
+  cursor: pointer;
+}
+
+button:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
+footer {
+  margin: 40px 0 16px;
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+.response {
+  display: block;
+  min-height: 1.6em;
+  margin: 1em 0;
+  color: var(--muted);
+}

--- a/examples/hello-world/tsconfig.json
+++ b/examples/hello-world/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun", "react/canary"]
+  },
+  "include": ["server.ts", "src"]
+}

--- a/examples/hello-world/turbo.json
+++ b/examples/hello-world/turbo.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": { "outputs": [".ersc/**", ".vercel/output/**"] }
+  }
+}

--- a/packages/effective-rsc/README.md
+++ b/packages/effective-rsc/README.md
@@ -203,10 +203,12 @@ The package-root API is available only under the `react-server` condition. The f
 enables that condition for application authoring modules; importing `effective-rsc` from another
 runtime, including a Client Component, throws immediately.
 
-## Example and documentation
+## Examples and documentation
 
-The [event platform](https://github.com/nikhilsnayak/effective-rsc/tree/main/examples/event-platform)
-is the complete application example.
+- [Hello world](https://github.com/nikhilsnayak/effective-rsc/tree/main/examples/hello-world): a small
+  example with streaming, navigation, a counter, and a Server Function form.
+- [Event platform](https://github.com/nikhilsnayak/effective-rsc/tree/main/examples/event-platform):
+  the complete application example, using local SQLite persistence.
 
 - [Getting started](https://github.com/nikhilsnayak/effective-rsc/blob/main/packages/effective-rsc/docs/01-getting-started/index.md)
 - [Guides](https://github.com/nikhilsnayak/effective-rsc/blob/main/packages/effective-rsc/docs/02-guides/index.md)

--- a/packages/vercel/LICENSE
+++ b/packages/vercel/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026-present Nikhil S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vercel/README.md
+++ b/packages/vercel/README.md
@@ -1,0 +1,19 @@
+# @ersc/vercel
+
+Vercel deployment packaging for effective-rsc on Bun 1.4+.
+
+Add `@ersc/vercel` to the app's `devDependencies` and build with:
+
+```sh
+ersc build --adapter @ersc/vercel
+```
+
+This generates `.vercel/output/` with a Bun function, traced dependencies, and copied assets.
+No custom server entry or `vercel.json` is needed. Configure the Vercel project with the Other
+preset and your monorepo build settings, then deploy with `vercel deploy --prebuilt`.
+
+Public asset symlinks are copied as content, including targets outside the app. Broken or cyclic
+links fail packaging. Computed file reads may escape tracing; local databases are not persistent.
+Plain `ersc build` skips packaging and leaves previous deployment output untouched.
+
+See the [hello-world example](https://github.com/nikhilsnayak/effective-rsc/tree/main/examples/hello-world).

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@ersc/vercel",
+  "version": "0.0.0",
+  "description": "Vercel deployment adapter for effective-rsc",
+  "keywords": [
+    "bun",
+    "effect",
+    "react-server-components",
+    "vercel"
+  ],
+  "homepage": "https://github.com/nikhilsnayak/effective-rsc/tree/main/packages/vercel#readme",
+  "bugs": {
+    "url": "https://github.com/nikhilsnayak/effective-rsc/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nikhilsnayak/effective-rsc.git",
+    "directory": "packages/vercel"
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "type": "module",
+  "exports": {
+    "./build": {
+      "types": "./dist/build.d.ts",
+      "default": "./dist/build.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "rslib build",
+    "prepack": "bun run build",
+    "test": "bun run --bun vitest run"
+  },
+  "dependencies": {
+    "@vercel/nft": "1.11.0"
+  },
+  "devDependencies": {
+    "@effect/platform-bun": "catalog:",
+    "@effect/vitest": "catalog:",
+    "@rslib/core": "catalog:",
+    "@types/bun": "catalog:",
+    "effect": "catalog:",
+    "effective-rsc": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@effect/platform-bun": "catalog:",
+    "effect": "catalog:",
+    "effective-rsc": "workspace:*"
+  },
+  "engines": {
+    "bun": ">=1.4.0"
+  }
+}

--- a/packages/vercel/rslib.config.ts
+++ b/packages/vercel/rslib.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [{ bundle: false, dts: { bundle: false, tsgo: true }, format: 'esm', syntax: 'es2022' }],
+  output: { cleanDistPath: true, minify: false, sourceMap: true, target: 'node' },
+  source: { entry: { index: ['src/**'] }, tsconfigPath: './tsconfig.json' },
+});

--- a/packages/vercel/src/build.ts
+++ b/packages/vercel/src/build.ts
@@ -1,0 +1,17 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import { Effect } from 'effect';
+import type { BuildHook } from 'effective-rsc/build';
+
+import { packageForVercel, VercelBuildError } from './package';
+
+export const build: BuildHook = Effect.fn('@ersc/vercel/build')(function* (context) {
+  const serverEntry = yield* Effect.try({
+    try: () => Bun.resolveSync('effective-rsc/server', context.root),
+    catch: (cause) =>
+      new VercelBuildError({
+        message: 'Cannot resolve effective-rsc/server from the application.',
+        cause,
+      }),
+  });
+  yield* packageForVercel({ ...context, serverEntry });
+}, Effect.provide(BunServices.layer));

--- a/packages/vercel/src/package.ts
+++ b/packages/vercel/src/package.ts
@@ -1,0 +1,217 @@
+// FileSystem.stat follows symlinks; packaging needs to preserve the links themselves.
+// oxlint-disable-next-line effecttsgo/node-builtin-import
+import { lstat } from 'node:fs/promises';
+
+import { nodeFileTrace } from '@vercel/nft';
+import { Effect, FileSystem, Path, Schema } from 'effect';
+import type { BuildContext } from 'effective-rsc/build';
+
+export class VercelBuildError extends Schema.TaggedError<VercelBuildError>()('VercelBuildError', {
+  message: Schema.String,
+  cause: Schema.Defect(),
+}) {}
+
+const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
+
+export const commonDirectory = (
+  path: Path.Path,
+  applicationRoot: string,
+  serverEntry: string,
+): string => {
+  let base = path.resolve(applicationRoot);
+  while (path.relative(base, serverEntry).split(path.sep).includes('..')) {
+    base = path.dirname(base);
+  }
+  return base;
+};
+
+const traceDependencies = Effect.fnUntraced(function* (
+  applicationRoot: string,
+  frameworkEntry: string,
+  entries: ReadonlyArray<string>,
+) {
+  const path = yield* Path.Path;
+  // Files outside NFT's base are omitted: https://github.com/vercel/nft#base
+  let base = commonDirectory(path, applicationRoot, frameworkEntry);
+  while (true) {
+    const trace = yield* Effect.tryPromise({
+      try: () =>
+        nodeFileTrace([...entries], {
+          base,
+          processCwd: applicationRoot,
+          // Custom conditions replace NFT's defaults: https://github.com/vercel/nft#exports--imports
+          conditions: ['bun', 'node', 'node-addons'],
+          mixedModules: true,
+        }),
+      catch: (cause) =>
+        new VercelBuildError({ message: 'Failed to trace deployment dependencies.', cause }),
+    });
+    if (trace.warnings.size > 0) {
+      return yield* new VercelBuildError({
+        message: 'Could not trace every deployment dependency.',
+        cause: new AggregateError(trace.warnings),
+      });
+    }
+    let expandedBase = base;
+    // NFT silently ignores dependencies outside base, without emitting a warning.
+    for (const [file, reason] of trace.reasons) {
+      if (reason.ignored) {
+        expandedBase = commonDirectory(path, expandedBase, path.resolve(base, file));
+      }
+    }
+    if (expandedBase === base) {
+      return { base, files: trace.fileList };
+    }
+    base = expandedBase;
+  }
+});
+
+const copyAssets: (
+  source: string,
+  destination: string,
+  ancestors: ReadonlyArray<string>,
+) => Effect.Effect<void, VercelBuildError, FileSystem.FileSystem | Path.Path> = Effect.fnUntraced(
+  function* (source, destination, ancestors) {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    // Copy asset link targets; their original locations will not exist after deployment.
+    const resolved = yield* fs.realPath(source);
+    const info = yield* fs.stat(resolved);
+    if (info.type === 'Directory') {
+      if (destination === resolved || destination.startsWith(`${resolved}${path.sep}`)) {
+        return yield* new VercelBuildError({
+          message: `Asset directory ${source} contains the deployment destination.`,
+          cause: resolved,
+        });
+      }
+      if (ancestors.includes(resolved)) {
+        return yield* new VercelBuildError({
+          message: `Asset directory ${source} contains a cyclic symlink.`,
+          cause: resolved,
+        });
+      }
+      yield* fs.makeDirectory(destination, { recursive: true });
+      const entries = yield* fs.readDirectory(resolved);
+      for (const entry of entries) {
+        yield* copyAssets(path.join(resolved, entry), path.join(destination, entry), [
+          ...ancestors,
+          resolved,
+        ]);
+      }
+    } else if (info.type === 'File') {
+      yield* fs.copyFile(resolved, destination);
+    } else {
+      return yield* new VercelBuildError({
+        message: `Asset ${source} is not a regular file or directory.`,
+        cause: info.type,
+      });
+    }
+  },
+  Effect.mapError(
+    (cause) => new VercelBuildError({ message: 'Failed to copy deployment assets.', cause }),
+  ),
+);
+
+export const packageForVercel = Effect.fn('@ersc/vercel/packageForVercel')(function* ({
+  root,
+  serverDir,
+  clientDir,
+  publicDir,
+  serverEntry,
+}: BuildContext & {
+  readonly serverEntry: string;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const applicationRoot = yield* fs.realPath(root);
+  const frameworkEntry = yield* fs.realPath(serverEntry);
+  const bootDirectory = path.join(applicationRoot, '.vercel/ersc');
+  const bootFile = path.join(bootDirectory, 'server.mjs');
+  const output = path.join(applicationRoot, '.vercel/output');
+  // A .func directory must contain every runtime file: https://vercel.com/docs/build-output-api/primitives#functions
+  const functionDirectory = path.join(output, 'functions/index.func');
+  const moduleSpecifier = path.relative(bootDirectory, frameworkEntry).split(path.sep).join('/');
+
+  yield* fs.makeDirectory(bootDirectory, { recursive: true });
+  // Bun.serve entrypoints: https://vercel.com/docs/functions/runtimes/bun#deploy-with-the-bun-framework-preset
+  // App-relative file reads: https://vercel.com/kb/guide/how-can-i-use-files-in-serverless-functions
+  // Change cwd before importing: module initialization may read application files.
+  yield* fs.writeFileString(
+    bootFile,
+    `import { fileURLToPath } from 'node:url';
+const root = fileURLToPath(new URL('../../', import.meta.url));
+process.chdir(root);
+const { start } = await import(${encodeJson(moduleSpecifier.startsWith('.') ? moduleSpecifier : `./${moduleSpecifier}`)});
+// Hostname and port are local-only; Vercel handles incoming traffic.
+await start({ root, hostname: 'localhost', port: 18193 });
+`,
+  );
+
+  // Seed every server chunk; runtime-selected imports may be invisible to tracing.
+  const serverFiles = yield* fs.readDirectory(serverDir, { recursive: true });
+  const { base, files } = yield* traceDependencies(applicationRoot, frameworkEntry, [
+    bootFile,
+    ...serverFiles.filter((file) => file.endsWith('.js')).map((file) => path.join(serverDir, file)),
+  ]);
+
+  // Keep the previous output if dependency tracing fails.
+  yield* fs.remove(output, { recursive: true, force: true });
+  yield* fs.makeDirectory(functionDirectory, { recursive: true });
+  yield* Effect.forEach(files, (file) =>
+    Effect.gen(function* () {
+      const source = path.join(base, file);
+      const destination = path.join(functionDirectory, file);
+      const info = yield* Effect.tryPromise({
+        try: () => lstat(source),
+        catch: (cause) => new VercelBuildError({ message: `Failed to inspect ${file}.`, cause }),
+      });
+      yield* fs.makeDirectory(path.dirname(destination), { recursive: true });
+      if (info.isSymbolicLink()) {
+        const target = yield* fs.readLink(source);
+        const targetPath = path.resolve(path.dirname(source), target);
+        const relativeTarget = path.relative(base, targetPath);
+        if (relativeTarget.split(path.sep).includes('..')) {
+          return yield* new VercelBuildError({
+            message: `Dependency ${file} points outside the deployment root.`,
+            cause: target,
+          });
+        }
+        // Rebase links onto the copied tree, including originally absolute links.
+        yield* fs.symlink(
+          path.relative(path.dirname(destination), path.join(functionDirectory, relativeTarget)),
+          destination,
+        );
+      } else if (info.isFile()) {
+        yield* fs.copyFile(source, destination);
+      }
+    }),
+  );
+
+  const deployedRoot = path.join(functionDirectory, path.relative(base, applicationRoot));
+  for (const source of [clientDir, publicDir]) {
+    // Directory entries distinguish missing assets from broken symlinks.
+    const entries = yield* fs.readDirectory(path.dirname(source));
+    if (entries.includes(path.basename(source))) {
+      const destination = path.join(deployedRoot, path.relative(root, source));
+      // Remove any traced symlink before copying files into this location.
+      yield* fs.remove(destination, { recursive: true, force: true });
+      yield* copyAssets(source, destination, []);
+    }
+  }
+  // Function config and launcher: https://vercel.com/docs/build-output-api/primitives#serverless-function-configuration
+  yield* fs.writeFileString(
+    path.join(functionDirectory, '.vc-config.json'),
+    encodeJson({
+      // Bun runtime series: https://vercel.com/docs/functions/runtimes/bun#configuring-the-runtime
+      runtime: 'bun1.4.x',
+      handler: path.relative(base, bootFile).split(path.sep).join('/'),
+      launcherType: 'Nodejs',
+      shouldAddHelpers: false,
+    }),
+  );
+  // Route all methods through the app: https://vercel.com/docs/build-output-api/configuration#routes
+  yield* fs.writeFileString(
+    path.join(output, 'config.json'),
+    encodeJson({ version: 3, routes: [{ src: '/(.*)', dest: '/index' }] }),
+  );
+});

--- a/packages/vercel/tests/package.test.ts
+++ b/packages/vercel/tests/package.test.ts
@@ -1,0 +1,242 @@
+import * as BunServices from '@effect/platform-bun/BunServices';
+import { expect, it } from '@effect/vitest';
+import { Effect, FileSystem, Path, Schema } from 'effect';
+import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process';
+
+import { commonDirectory, packageForVercel } from '../src/package';
+
+const fixture = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const workspace = yield* fs.makeTempDirectoryScoped({ prefix: 'ersc-vercel-' });
+  const root = path.join(workspace, 'apps/with spaces');
+  const serverEntry = path.join(workspace, 'framework/start.js');
+  const write = Effect.fnUntraced(function* (file: string, contents: string) {
+    yield* fs.makeDirectory(path.dirname(file), { recursive: true });
+    yield* fs.writeFileString(file, contents);
+  });
+  yield* write(serverEntry, 'export async function start() {}');
+  yield* write(path.join(root, '.ersc/server/main.js'), 'import "dependency"; export default {};');
+  yield* write(path.join(root, '.ersc/client/main.js'), 'console.log("client");');
+  yield* write(path.join(root, 'public/icon.svg'), '<svg/>');
+  yield* write(path.join(root, '.env.local'), 'NOT_FOR_DEPLOYMENT=secret');
+  yield* write(
+    path.join(workspace, 'store/dependency/package.json'),
+    '{"name":"dependency","type":"module","exports":"./index.js"}',
+  );
+  yield* write(path.join(workspace, 'store/dependency/index.js'), 'export const value = 1;');
+  yield* fs.makeDirectory(path.join(root, 'node_modules'), { recursive: true });
+  yield* fs.symlink(
+    path.join(workspace, 'store/dependency'),
+    path.join(root, 'node_modules/dependency'),
+  );
+  const context = {
+    root,
+    serverDir: path.join(root, '.ersc/server'),
+    clientDir: path.join(root, '.ersc/client'),
+    publicDir: path.join(root, 'public'),
+    serverEntry,
+  };
+  return { fs, path, root, workspace, context, write };
+});
+
+it.effect('finds a shared root for standalone and workspace installations', () =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    expect(
+      commonDirectory(path, '/app', '/app/node_modules/effective-rsc/dist/server/start.js'),
+    ).toBe('/app');
+    expect(
+      commonDirectory(path, '/repo/apps/web', '/repo/packages/framework/dist/server/start.js'),
+    ).toBe('/repo');
+  }).pipe(Effect.provide(Path.layer)),
+);
+
+it.effect(
+  'packages traced dependencies, rewrites absolute symlinks, and excludes local secrets',
+  () =>
+    Effect.gen(function* () {
+      const { fs, path, root, context } = yield* fixture;
+      yield* packageForVercel(context);
+      const output = path.join(root, '.vercel/output/functions/index.func');
+      const dependency = path.join(output, 'apps/with spaces/node_modules/dependency');
+      const link = yield* fs.readLink(dependency);
+      const source = yield* fs.readFileString(path.join(dependency, 'index.js'));
+      const secretExists = yield* fs.exists(path.join(output, 'apps/with spaces/.env.local'));
+      const icon = yield* fs.readFileString(path.join(output, 'apps/with spaces/public/icon.svg'));
+      const client = yield* fs.readFileString(
+        path.join(output, 'apps/with spaces/.ersc/client/main.js'),
+      );
+      const config = yield* fs.readFileString(path.join(output, '.vc-config.json'));
+      expect(link).toBe('../../../store/dependency');
+      expect(source).toContain('value = 1');
+      expect(secretExists).toBe(false);
+      expect(icon).toBe('<svg/>');
+      expect(client).toContain('client');
+      const decodedConfig = yield* Schema.decodeEffect(Schema.fromJsonString(Schema.Unknown))(
+        config,
+      );
+      expect(decodedConfig).toMatchObject({
+        runtime: 'bun1.4.x',
+        handler: 'apps/with spaces/.vercel/ersc/server.mjs',
+      });
+      yield* fs.writeFileString(path.join(output, 'stale.js'), 'old build');
+      yield* packageForVercel(context);
+      const staleExists = yield* fs.exists(path.join(output, 'stale.js'));
+      expect(staleExists).toBe(false);
+    }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
+);
+
+it.effect('fails unresolved dependency tracing before replacing an existing output', () =>
+  Effect.gen(function* () {
+    const { fs, path, root, context, write } = yield* fixture;
+    const marker = path.join(root, '.vercel/output/previous.json');
+    yield* write(marker, 'keep');
+    yield* write(
+      path.join(root, '.ersc/server/main.js'),
+      'import "missing-package-for-ersc-test";',
+    );
+    const error = yield* packageForVercel(context).pipe(Effect.flip);
+    expect(error).toMatchObject({ _tag: 'VercelBuildError' });
+    const previous = yield* fs.readFileString(marker);
+    expect(previous).toBe('keep');
+  }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
+);
+
+for (const condition of ['bun', 'node', 'node-addons']) {
+  it.effect(`packages the ${condition} export selected by Bun`, () =>
+    Effect.gen(function* () {
+      const { fs, path, root, workspace, context, write } = yield* fixture;
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      yield* write(
+        path.join(workspace, 'store/dependency/package.json'),
+        `{"name":"dependency","type":"module","exports":{"${condition}":"./selected.js","default":"./fallback.js"}}`,
+      );
+      yield* write(
+        path.join(workspace, 'store/dependency/selected.js'),
+        'console.log("selected");',
+      );
+      yield* write(
+        path.join(workspace, 'store/dependency/fallback.js'),
+        'console.log("fallback");',
+      );
+      yield* packageForVercel(context);
+      const output = path.join(root, '.vercel/output/functions/index.func');
+      const selected = yield* fs.exists(path.join(output, 'store/dependency/selected.js'));
+      expect(selected).toBe(true);
+      const result = yield* spawner.string(
+        ChildProcess.make('bun', ['apps/with spaces/.ersc/server/main.js'], { cwd: output }),
+      );
+      expect(result.trim()).toBe('selected');
+    }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
+  );
+}
+
+it.effect('restores the application cwd before importing the relocated entry', () =>
+  Effect.gen(function* () {
+    const { fs, path, root, context, write } = yield* fixture;
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    yield* write(path.join(root, 'content.md'), 'packaged content');
+    yield* write(
+      path.join(context.serverDir, 'main.js'),
+      `import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+console.log(readFileSync(join(process.cwd(), 'content.md'), 'utf8'));
+`,
+    );
+    yield* write(
+      context.serverEntry,
+      `import '../apps/with spaces/.ersc/server/main.js';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+const content = readFileSync(join(process.cwd(), 'content.md'), 'utf8');
+export async function start() { console.log(content); }
+`,
+    );
+    yield* packageForVercel(context);
+    const isolated = yield* fs.makeTempDirectoryScoped({ prefix: 'ersc-vercel-isolated-' });
+    const output = path.join(isolated, 'index.func');
+    yield* fs.rename(path.join(root, '.vercel/output/functions/index.func'), output);
+    const content = yield* fs.readFileString(path.join(output, 'apps/with spaces/content.md'));
+    expect(content).toBe('packaged content');
+    const result = yield* spawner.string(
+      ChildProcess.make('bun', ['apps/with spaces/.vercel/ersc/server.mjs'], { cwd: output }),
+    );
+    expect(result.trim()).toBe('packaged content\npackaged content');
+  }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
+);
+
+it.effect(
+  'retraces hoisted dependencies and their transitive imports outside the initial root',
+  () =>
+    Effect.gen(function* () {
+      const { fs, path, root, workspace, context, write } = yield* fixture;
+      const serverEntry = path.join(root, 'framework/start.js');
+      yield* write(serverEntry, 'export async function start() {}');
+      yield* write(path.join(context.serverDir, 'main.js'), 'import "hoisted";');
+      yield* write(
+        path.join(workspace, 'apps/node_modules/hoisted/package.json'),
+        '{"name":"hoisted","type":"module","exports":"./index.js"}',
+      );
+      yield* write(
+        path.join(workspace, 'apps/node_modules/hoisted/index.js'),
+        'export { value } from "transitive";',
+      );
+      yield* write(
+        path.join(workspace, 'node_modules/transitive/package.json'),
+        '{"name":"transitive","type":"module","exports":"./index.js"}',
+      );
+      yield* write(
+        path.join(workspace, 'node_modules/transitive/index.js'),
+        'export const value = 42;',
+      );
+      yield* write(path.join(workspace, 'unrelated/private.txt'), 'must not be copied');
+      yield* packageForVercel({ ...context, serverEntry });
+      const output = path.join(root, '.vercel/output/functions/index.func');
+      const hoisted = yield* fs.readFileString(
+        path.join(output, 'apps/node_modules/hoisted/index.js'),
+      );
+      const transitive = yield* fs.readFileString(
+        path.join(output, 'node_modules/transitive/index.js'),
+      );
+      const unrelated = yield* fs.exists(path.join(output, 'unrelated/private.txt'));
+      expect(hoisted).toContain('transitive');
+      expect(transitive).toContain('42');
+      expect(unrelated).toBe(false);
+    }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
+);
+
+it.effect('copies linked public directories and client files as self-contained assets', () =>
+  Effect.gen(function* () {
+    const { fs, path, root, workspace, context, write } = yield* fixture;
+    const shared = path.join(workspace, 'shared');
+    yield* write(path.join(shared, 'images/logo.svg'), '<svg>shared</svg>');
+    yield* write(path.join(shared, 'client.js'), 'shared client');
+    yield* fs.symlink(path.join(shared, 'images'), path.join(context.publicDir, 'images'));
+    yield* fs.symlink('images/logo.svg', path.join(context.publicDir, 'alias.svg'));
+    yield* fs.symlink(path.join(shared, 'client.js'), path.join(context.clientDir, 'linked.js'));
+    yield* packageForVercel(context);
+    // Removing fixture-owned targets proves the deployed assets no longer rely on their links.
+    yield* fs.remove(shared, { recursive: true });
+    const output = path.join(root, '.vercel/output/functions/index.func/apps/with spaces');
+    const logo = yield* fs.readFileString(path.join(output, 'public/images/logo.svg'));
+    const alias = yield* fs.readFileString(path.join(output, 'public/alias.svg'));
+    const client = yield* fs.readFileString(path.join(output, '.ersc/client/linked.js'));
+    expect(logo).toBe('<svg>shared</svg>');
+    expect(alias).toBe(logo);
+    expect(client).toBe('shared client');
+  }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
+);
+
+for (const target of ['missing.svg', '.', '../../..']) {
+  it.effect(`rejects broken, cyclic, or self-containing asset links: ${target}`, () =>
+    Effect.gen(function* () {
+      const { fs, path, root, context } = yield* fixture;
+      yield* fs.symlink(target, path.join(context.publicDir, 'invalid'));
+      const error = yield* packageForVercel(context).pipe(Effect.flip);
+      expect(error).toMatchObject({ _tag: 'VercelBuildError' });
+      const complete = yield* fs.exists(path.join(root, '.vercel/output/config.json'));
+      expect(complete).toBe(false);
+    }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
+  );
+}

--- a/packages/vercel/tsconfig.json
+++ b/packages/vercel/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": { "rootDir": "./src", "types": ["bun"] },
+  "include": ["src"]
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,20 +43,16 @@ if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
   exit 1
 fi
 
-effective_rsc_version="$(bun -e 'console.log(require("./packages/effective-rsc/package.json").version)')"
-create_ersc_app_version="$(bun -e 'console.log(require("./packages/create-ersc-app/package.json").version)')"
+packages=(effective-rsc vercel create-ersc-app)
+for package in "${packages[@]}"; do
+  package_version="$(bun -e 'console.log(require(process.argv[1]).version)' "./packages/$package/package.json")"
+  if [[ "$package_version" != "$version" ]]; then
+    echo "packages/$package is $package_version, expected $version." >&2
+    exit 1
+  fi
+done
+
 template_framework_version="$(bun -e 'console.log(require("./packages/create-ersc-app/template/package.json").dependencies["effective-rsc"])')"
-
-if [[ "$effective_rsc_version" != "$version" ]]; then
-  echo "effective-rsc is $effective_rsc_version, expected $version." >&2
-  exit 1
-fi
-
-if [[ "$create_ersc_app_version" != "$version" ]]; then
-  echo "create-ersc-app is $create_ersc_app_version, expected $version." >&2
-  exit 1
-fi
-
 if [[ "$template_framework_version" != "$version" ]]; then
   echo "The create-ersc-app template uses effective-rsc $template_framework_version, expected $version." >&2
   exit 1
@@ -66,17 +62,19 @@ bun run check
 bun run build
 bun run test
 
-bun publish --cwd packages/effective-rsc --dry-run
-bun publish --cwd packages/create-ersc-app --dry-run
+for package in "${packages[@]}"; do
+  bun publish --cwd "packages/$package" --dry-run
+done
 
-read -r -p "Publish effective-rsc and create-ersc-app $version, then push $tag? Type release: " confirmation
+read -r -p "Publish effective-rsc, @ersc/vercel, and create-ersc-app $version, then push $tag? Type release: " confirmation
 if [[ "$confirmation" != "release" ]]; then
   echo "Release canceled." >&2
   exit 1
 fi
 
-bun publish --cwd packages/effective-rsc
-bun publish --cwd packages/create-ersc-app
+for package in "${packages[@]}"; do
+  bun publish --cwd "packages/$package"
+done
 
 git tag --annotate "$tag" --message "Release $version"
 git push origin "$tag"


### PR DESCRIPTION
Add the optional Vercel adapter with dependency tracing and asset packaging, plus the hello-world deployment example and release integration. Building generates output; it does not deploy.

Validation: independent lower-stack build and checks pass; all 12 adapter tests pass.