### PR TITLE
feat: add link transition types and polish site navigation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -183,6 +183,8 @@
         "@effect/platform-browser": "catalog:",
         "@effect/platform-bun": "catalog:",
         "@sugar-high/react": "2.2.2",
+        "@vercel/analytics": "2.0.1",
+        "@vercel/speed-insights": "2.0.0",
         "class-variance-authority": "catalog:",
         "cn": "catalog:",
         "effect": "catalog:",
@@ -697,7 +699,11 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
+    "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
+
     "@vercel/nft": ["@vercel/nft@1.11.0", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "@rollup/pluginutils": "^5.1.3", "acorn": "^8.6.0", "acorn-import-attributes": "^1.9.5", "async-sema": "^3.1.1", "bindings": "^1.4.0", "estree-walker": "2.0.2", "glob": "^13.0.0", "graceful-fs": "^4.2.9", "node-gyp-build": "^4.2.2", "picomatch": "^4.0.4", "resolve-from": "^5.0.0" }, "bin": { "nft": "out/cli.js" } }, "sha512-m1QFg+U+3yPOnP1xSYJ73UIRxLOXdts1JOhiOiyPYqEsALgrXFFINvgUaD6R6iNvaBFAjHllBCbkfx4FuOdpaA=="],
+
+    "@vercel/speed-insights": ["@vercel/speed-insights@2.0.0", "", { "peerDependencies": { "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.11", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw=="],
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -74,6 +74,7 @@ entry; read Git history for what it said.
 | D-068 | Let ServerFn input be one Schema for one argument or a readonly schema list for positional arguments, including previous state and FormData for native useActionState. A Tuple or Array Schema remains a single argument. Resolves OQ-008.                        |
 | D-069 | Decode Page params once in the request handler before GET/HEAD rendering; rejection returns an empty 404, including Flight. POST keeps render-time decoding and completed Server Function outcomes. Resolves OQ-003.                                              |
 | D-070 | Select one installed deployment adapter with ersc build --adapter <package>; invoke its fixed ./build export after compilation. No dependency scanning, manifest marker, automatic installation, or upload. Core remains host-independent.                        |
+| D-071 | Read additive application transition types from native links via data-ersc-transition-types at navigation start; publish them with the route and do not persist them in history. Typed client navigation APIs remain deferred.                                    |
 
 ## Deferred
 

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -80,3 +80,19 @@ IDs are append-only and never reused, including after a question is resolved.
 - **Resolution:** Keep native behavior initially. A future design must key positions by history
   entry and choose a restoration point that accounts for later streamed reveals.
 - **Status:** Deferred; native behavior remains the initial policy.
+
+### OQ-010 — Typed application navigation transition APIs
+
+- **Question:** How should public client navigation APIs provide type-safe application transition
+  names for both links and programmatic navigation?
+- **Why:** Plain data attributes provide navigation intent without committing to a Link component,
+  helper factory, or global type-registration API.
+- **Affected:** Client public exports, native links, programmatic navigation, and React View
+  Transition type maps.
+- **Evidence:** D-071 supports `data-ersc-transition-types` on native links. The documentation site
+  uses application types to distinguish Previous, Next, and unordered navigation from history
+  direction, but plain attribute values do not catch misspelled application types.
+- **Related:** D-018, D-047, D-067, D-071.
+- **Resolution:** Use plain data attributes now; revisit naming, API shape, and type safety together
+  with framework-level public client APIs.
+- **Status:** Deferred until public client APIs are designed.

--- a/docs/architecture/client-router.md
+++ b/docs/architecture/client-router.md
@@ -1,6 +1,6 @@
 # Client router
 
-Status: **Current** under [D-063, D-066, and D-067](../DECISIONS.md).
+Status: **Current** under [D-063, D-066, D-067, and D-071](../DECISIONS.md).
 
 ## Purpose
 
@@ -86,6 +86,27 @@ Transition types are additive:
 A replace navigation has no direction type. A traversal also has no direction type when its source
 index is unavailable or equal to its destination index. Applications may use the UA visual and HMR
 types to suppress author animation, but ERSC does not impose that styling policy.
+
+For routed push and replace navigations, a native `<a href>` may supply a whitespace-separated
+`data-ersc-transition-types` attribute. When `NavigateEvent.sourceElement` is an `HTMLAnchorElement`,
+the router reads its `dataset.erscTransitionTypes` once, synchronously when accepting the event,
+and appends its unique types after the built-in types at route publication. Changing or removing the link while Flight
+loads cannot change that navigation's types. Types stay local to that navigation, including an
+intercepted Flight redirect; they are not stored in URLs, history entries, or router state.
+Superseded loading work cannot publish its types. A full-document fallback carries no custom types.
+
+Only ERSC-owned names are reserved: `navigation`, `navigation-*`, `server-function`, and
+`hmr-refresh`. These names are matched case-sensitively and ignored in the attribute. All other
+non-whitespace tokens pass through unchanged; ERSC does not validate React or CSS naming rules.
+Duplicate tokens are added once, preserving attribute order. Absent attributes or source links
+contribute no types. Traversal never reads or
+replays link metadata, and ineligible navigations retain native behavior.
+
+Application types are additive context, not overrides of history facts: a Previous link can carry
+both `navigation-forward` (a push) and `docs-previous` (document order). React combines matching
+classes from a `<ViewTransition>` type map; applications resolve animation precedence in their CSS.
+Typed authoring helpers and public client navigation APIs remain deferred in
+[OQ-010](../OPEN_QUESTIONS.md).
 
 These types describe the first publication only. Nested Suspense content can reveal in later React
 Transitions after native navigation has finished; React does not carry the router's types into those

--- a/fixtures/framework-e2e/e2e/navigation.spec.ts
+++ b/fixtures/framework-e2e/e2e/navigation.spec.ts
@@ -66,6 +66,40 @@ test('moves between route groups through the composed catalog', async ({ page })
   expect(browserErrors).toEqual([]);
 });
 
+test('publishes native link types once without replaying them on history traversal', async ({
+  page,
+}) => {
+  const browserErrors = observeBrowserErrors(page);
+  await observeViewTransitions(page);
+  await page.goto('/catalog/primary');
+  const link = page.getByRole('link', { name: 'Open Secondary' });
+  await link.evaluate((element: HTMLAnchorElement) => {
+    element.dataset['erscTransitionTypes'] = 'docs-previous docs-previous section-change';
+    const child = document.createElement('span');
+    child.textContent = 'Nested link content';
+    element.append(child);
+  });
+  await link.getByText('Nested link content').click();
+  await expect(page).toHaveURL('/catalog/secondary');
+  await waitForViewTransition(page, [
+    'navigation',
+    'navigation-push',
+    'navigation-forward',
+    'docs-previous',
+    'section-change',
+  ]);
+  await expect(page.locator('[data-detail-id="secondary-slow-stream"]')).toBeVisible();
+
+  await page.evaluate(() => window.navigation.back().finished);
+  await waitForViewTransition(page, ['navigation', 'navigation-traverse', 'navigation-backward']);
+  await page.evaluate(() => window.navigation.forward().finished);
+  await waitForViewTransition(page, ['navigation', 'navigation-traverse', 'navigation-forward']);
+
+  await page.evaluate(() => window.navigation.navigate('/catalog/primary').finished);
+  await waitForViewTransition(page, ['navigation', 'navigation-push', 'navigation-forward']);
+  expect(browserErrors).toEqual([]);
+});
+
 test('types a replace navigation without inventing a direction', async ({ page }) => {
   const browserErrors = observeBrowserErrors(page);
   await observeViewTransitions(page);

--- a/packages/effective-rsc/LLMS.md
+++ b/packages/effective-rsc/LLMS.md
@@ -279,6 +279,23 @@ These types describe only the first publication. Suspense content that resolves 
 separate, untyped React Transition. Applications should use their own Suspense-specific
 `<ViewTransition>` boundaries and styling for those reveals.
 
+#### Application transition types
+
+Add whitespace-separated application transition types to a native link with
+`data-ersc-transition-types`:
+
+```tsx
+<a href='/photos/2' data-ersc-transition-types='photo-next'>
+  Next photo
+</a>
+```
+
+These are added alongside ERSC's built-in types for that push or replace navigation and can be
+used in your `<ViewTransition>` type maps. They are not replayed on Back/Forward.
+
+The names `navigation`, `navigation-*`, `server-function`, and `hmr-refresh` are reserved for ERSC
+and ignored in the attribute.
+
 ## Server Function execution and refresh
 
 Hydrated invocations and progressively enhanced forms execute the same request-scoped Effect

--- a/packages/effective-rsc/docs/03-advanced/02-client-navigation/index.md
+++ b/packages/effective-rsc/docs/03-advanced/02-client-navigation/index.md
@@ -62,3 +62,20 @@ but ERSC does not impose that policy.
 These types describe only the first publication. Suspense content that resolves later renders in a
 separate, untyped React Transition. Applications should use their own Suspense-specific
 `<ViewTransition>` boundaries and styling for those reveals.
+
+#### Application transition types
+
+Add whitespace-separated application transition types to a native link with
+`data-ersc-transition-types`:
+
+```tsx
+<a href='/photos/2' data-ersc-transition-types='photo-next'>
+  Next photo
+</a>
+```
+
+These are added alongside ERSC's built-in types for that push or replace navigation and can be
+used in your `<ViewTransition>` type maps. They are not replayed on Back/Forward.
+
+The names `navigation`, `navigation-*`, `server-function`, and `hmr-refresh` are reserved for ERSC
+and ignored in the attribute.

--- a/packages/effective-rsc/src/client/client-router.ts
+++ b/packages/effective-rsc/src/client/client-router.ts
@@ -14,6 +14,22 @@ import { RouteLoader, type RouteLoad } from './route-loader';
 type NavigationGeneration = symbol;
 type RouteResource = Extract<RouteLoad, { readonly _tag: 'Route' }>;
 
+const reservedTransitionTypes = new Set(['navigation', 'server-function', 'hmr-refresh']);
+
+const isApplicationTransitionType = (type: string) =>
+  !reservedTransitionTypes.has(type) && !type.startsWith('navigation-');
+
+const getLinkTransitionTypes = (event: NavigateEvent): ReadonlyArray<string> => {
+  if (
+    (event.navigationType !== 'push' && event.navigationType !== 'replace') ||
+    !(event.sourceElement instanceof HTMLAnchorElement)
+  ) {
+    return [];
+  }
+  const types = event.sourceElement.dataset['erscTransitionTypes']?.match(/\S+/g) ?? [];
+  return [...new Set(types.filter(isApplicationTransitionType))];
+};
+
 const getNavigationTransitionTypes = (
   event: NavigateEvent,
   fromIndex: number | null,
@@ -431,6 +447,7 @@ export const installClientRouter = Effect.gen(function* () {
     }
 
     const destination = new URL(event.destination.url);
+    const linkTransitionTypes = getLinkTransitionTypes(event);
     const generation: NavigationGeneration = Symbol('NavigationGeneration');
     const lifetime = new AbortController();
     const navigationSignal = AbortSignal.any([event.signal, lifetime.signal]);
@@ -498,6 +515,9 @@ export const installClientRouter = Effect.gen(function* () {
                 navigationApi.getCurrentEntry()?.index ??
                 null;
               for (const type of getNavigationTransitionTypes(event, fromIndex)) {
+                addTransitionType(type);
+              }
+              for (const type of linkTransitionTypes) {
                 addTransitionType(type);
               }
               navigation = browserRenderer.navigate(command.resource.routeTree);

--- a/packages/effective-rsc/tests/client/client-router.test.ts
+++ b/packages/effective-rsc/tests/client/client-router.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, it } from '@effect/vitest';
+import { afterEach, beforeEach, expect, it } from '@effect/vitest';
 import { Deferred, Effect, Exit, Fiber, Layer, Scope } from 'effect';
 import { HttpClient, HttpClientResponse } from 'effect/unstable/http';
 import { vi } from 'vitest';
@@ -44,6 +44,14 @@ import { RouteLoader, type RouteLoad } from '../../src/client/route-loader';
 import type { RouteTreeModel } from '../../src/rsc/route-tree';
 
 const FlightClientLayer = FlightClient.layer.pipe(Layer.provide(InitialFlightStream.layer));
+
+class TestAnchor {
+  readonly dataset: DOMStringMap;
+
+  constructor(dataset: DOMStringMap) {
+    this.dataset = dataset;
+  }
+}
 
 type TestNavigateEvent = Event &
   Pick<
@@ -135,6 +143,7 @@ type TestNavigateEventOverrides = Partial<
 > & {
   readonly cancelable?: boolean;
   readonly destination?: { readonly id?: string; readonly key?: string; readonly url: string };
+  readonly sourceElement?: Pick<HTMLAnchorElement, 'dataset'> | null;
 };
 
 const makeNavigationEvent = (overrides: TestNavigateEventOverrides = {}) => {
@@ -179,7 +188,10 @@ const makeNavigationEvent = (overrides: TestNavigateEventOverrides = {}) => {
 
 beforeEach(() => {
   react.transitionTypes.length = 0;
+  vi.stubGlobal('HTMLAnchorElement', TestAnchor);
 });
+
+afterEach(() => vi.unstubAllGlobals());
 
 const makeHttpClient = (requestedUrls: Array<string> = [], contentType = 'text/x-component') =>
   HttpClient.make((request) =>
@@ -418,6 +430,120 @@ it.effect('splits a cancelable navigation between React commit and Flight comple
       }),
     );
   }),
+);
+
+it.effect('snapshots link types before loading and keeps them local to the navigation', () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const navigation = new TestNavigationApi();
+      yield* listen(navigation);
+      const anchor = new TestAnchor({
+        erscTransitionTypes: ' docs-previous\tsection-change docs-previous\n',
+      });
+      const pending = makeNavigationEvent({ sourceElement: anchor });
+      navigation.dispatch(pending.event);
+      anchor.dataset['erscTransitionTypes'] = 'docs-next';
+      expect(react.transitionTypes).toEqual([]);
+
+      const handler = pending.interception()?.precommitHandler;
+      if (handler === undefined) {
+        return yield* Effect.die('Expected a precommit handler.');
+      }
+      yield* Effect.promise(() => invokePrecommitHandler(handler, makePrecommitController()));
+      expect(react.transitionTypes).toEqual([
+        'navigation',
+        'navigation-push',
+        'navigation-forward',
+        'docs-previous',
+        'section-change',
+      ]);
+
+      react.transitionTypes.length = 0;
+      yield* prepareNavigation(navigation, 'https://effective-rsc.test/schedule/day-two');
+      expect(react.transitionTypes).toEqual([
+        'navigation',
+        'navigation-push',
+        'navigation-forward',
+      ]);
+    }),
+  ),
+);
+
+it.effect('reserves only ERSC-owned types and preserves application tokens unchanged', () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const navigation = new TestNavigationApi();
+      const renders: Array<BrowserRenderRequest> = [];
+      yield* listen(navigation, makeBrowserRenderer(renders));
+      const applicationTypes = [
+        'docs-jump',
+        'NAVIGATION-BACKWARD',
+        'none',
+        'initial',
+        'default',
+        'constructor',
+        'toString',
+        '1custom',
+        'custom/type',
+        'étape-suivante',
+      ];
+      const pending = makeNavigationEvent({
+        navigationType: 'replace',
+        sourceElement: new TestAnchor({
+          erscTransitionTypes: [
+            'navigation',
+            'navigation-backward',
+            'navigation-custom',
+            'server-function',
+            'hmr-refresh',
+            ...applicationTypes,
+          ].join(' '),
+        }),
+      });
+      navigation.dispatch(pending.event);
+      const handler = pending.interception()?.precommitHandler;
+      if (handler === undefined) {
+        return yield* Effect.die('Expected a precommit handler.');
+      }
+      yield* Effect.promise(() => invokePrecommitHandler(handler, makePrecommitController()));
+      expect(renders).toHaveLength(1);
+      expect(react.transitionTypes).toEqual([
+        'navigation',
+        'navigation-replace',
+        ...applicationTypes,
+      ]);
+    }),
+  ),
+);
+
+it.effect('does not read link types for a history traversal', () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const navigation = new TestNavigationApi();
+      yield* listen(navigation);
+      const readTypes = vi.fn(() => 'docs-next');
+      const pending = makeNavigationEvent({
+        navigationType: 'traverse',
+        sourceElement: new TestAnchor({
+          get erscTransitionTypes() {
+            return readTypes();
+          },
+        }),
+      });
+      navigation.dispatch(pending.event);
+      const handler = pending.interception()?.precommitHandler;
+      if (handler === undefined) {
+        return yield* Effect.die('Expected a precommit handler.');
+      }
+      yield* Effect.promise(() => invokePrecommitHandler(handler, makePrecommitController()));
+      expect(readTypes).not.toHaveBeenCalled();
+      expect(react.transitionTypes).toEqual([
+        'navigation',
+        'navigation-traverse',
+        'navigation-backward',
+      ]);
+    }),
+  ),
 );
 
 it.effect('settles the post-commit handler before the Flight stream reaches EOF', () =>

--- a/site/package.json
+++ b/site/package.json
@@ -15,6 +15,8 @@
     "@effect/platform-browser": "catalog:",
     "@effect/platform-bun": "catalog:",
     "@sugar-high/react": "2.2.2",
+    "@vercel/analytics": "2.0.1",
+    "@vercel/speed-insights": "2.0.0",
     "class-variance-authority": "catalog:",
     "cn": "catalog:",
     "effect": "catalog:",

--- a/site/src/application.tsx
+++ b/site/src/application.tsx
@@ -1,5 +1,6 @@
 import { Effect, Schema } from 'effect';
 
+import { Telemetry } from './components/telemetry';
 import { ThemeToggle } from './components/theme-toggle';
 import { TooltipProvider } from './components/ui/tooltip';
 import { DocumentationLayout } from './docs/layout';
@@ -20,7 +21,7 @@ const themeScript = `try{const t=localStorage.getItem('ersc-theme');document.doc
 const RootLayout = ERSC.Layout.make({
   render: ({ children }) =>
     Effect.succeed(
-      <html lang='en' suppressHydrationWarning className='scroll-pt-24 [scrollbar-gutter:stable]'>
+      <html lang='en' suppressHydrationWarning className='scroll-pt-24 scrollbar-gutter-stable'>
         <head>
           <meta name='viewport' content='width=device-width, initial-scale=1' />
           <link rel='stylesheet' href='/fonts.css' />
@@ -53,8 +54,11 @@ const RootLayout = ERSC.Layout.make({
             >
               Skip to content
             </a>
-            <header className='bg-background sticky top-0 z-20 border-b print:hidden'>
-              <div className='mx-auto flex h-16 max-w-[1320px] items-center gap-2 px-4 md:h-18 md:gap-4 md:px-8'>
+            <header
+              className='bg-background sticky top-0 z-20 border-b print:hidden'
+              style={{ viewTransitionName: 'site-header' }}
+            >
+              <div className='mx-auto flex h-16 max-w-330 items-center gap-2 px-4 md:h-18 md:gap-4 md:px-8'>
                 <a
                   className='inline-flex items-center gap-2.5 text-[0.95rem] font-semibold tracking-tight'
                   href='/'
@@ -104,7 +108,7 @@ const RootLayout = ERSC.Layout.make({
             >
               {children}
             </main>
-            <footer className='text-muted-foreground bg-background relative z-10 mx-auto flex max-w-[1320px] items-start justify-between gap-4 border-t px-5 py-6 text-xs md:items-center md:px-8 print:hidden'>
+            <footer className='text-muted-foreground bg-background relative z-10 mx-auto flex max-w-330 items-start justify-between gap-4 border-t px-5 py-6 text-xs md:items-center md:px-8 print:hidden'>
               <div>
                 <span>Built with effective-rsc</span>
               </div>
@@ -131,6 +135,7 @@ const RootLayout = ERSC.Layout.make({
               </nav>
             </footer>
           </TooltipProvider>
+          <Telemetry />
         </body>
       </html>,
     ),

--- a/site/src/components/page-transition.tsx
+++ b/site/src/components/page-transition.tsx
@@ -1,0 +1,21 @@
+import { ViewTransition, type ReactNode } from 'react';
+
+const navigationClasses = {
+  default: 'none',
+  'navigation-forward': 'navigation-forward',
+  'navigation-backward': 'navigation-backward',
+  'docs-next': 'navigation-forward',
+  'docs-previous': 'navigation-backward',
+  'docs-jump': 'navigation-jump',
+  'server-function': 'none',
+  'navigation-ua-visual-transition': 'none',
+  'hmr-refresh': 'none',
+};
+
+export function PageTransition({ children }: { readonly children: ReactNode }) {
+  return (
+    <ViewTransition default='none' enter={navigationClasses} exit={navigationClasses}>
+      {children}
+    </ViewTransition>
+  );
+}

--- a/site/src/components/telemetry.tsx
+++ b/site/src/components/telemetry.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Analytics } from '@vercel/analytics/react';
+import { SpeedInsights } from '@vercel/speed-insights/react';
+
+import { usePathname } from '../hooks/use-pathname';
+
+export function Telemetry() {
+  const pathname = usePathname();
+  return (
+    <>
+      {/* Explicit paths track Navigation API commits and disable automatic pageviews. */}
+      <Analytics route={pathname} path={pathname} />
+      <SpeedInsights />
+    </>
+  );
+}

--- a/site/src/docs/layout.tsx
+++ b/site/src/docs/layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 
+import { PageTransition } from '../components/page-transition';
 import { Sidebar, SidebarContent, SidebarProvider, SidebarTrigger } from '../components/ui/sidebar';
 import type { DocEntry } from './model';
 import { DocsNavigation } from './navigation';
@@ -12,28 +13,30 @@ export function DocumentationLayout({
   readonly children: ReactNode;
 }) {
   return (
-    <SidebarProvider
-      className='mx-auto min-h-0 max-w-[1320px] gap-10 px-5 md:px-8 print:block'
-      style={{ '--sidebar-width': '14rem' } as React.CSSProperties}
-    >
-      <Sidebar className='sticky top-18 bottom-auto h-[calc(100svh-4.5rem)] pr-4 pb-10 group-data-[collapsible=offcanvas]:w-0 group-data-[collapsible=offcanvas]:overflow-hidden group-data-[collapsible=offcanvas]:pr-0 data-[side=left]:left-auto data-[side=left]:border-r-0'>
-        <SidebarContent className='scroll-py-4 overscroll-contain py-8 md:mask-[linear-gradient(to_bottom,transparent,black_12px,black_calc(100%-12px),transparent)]'>
-          <DocsNavigation entries={entries} />
-        </SidebarContent>
-      </Sidebar>
-      <div className='min-w-0 flex-1'>
-        <div className='mt-4 mb-6 flex items-center gap-2 md:hidden print:hidden'>
-          <SidebarTrigger className='size-10' aria-label='Open documentation menu' />
-          <span className='text-sm'>Documentation</span>
-          <a
-            href='/docs'
-            className='text-muted-foreground ml-auto text-xs underline underline-offset-4'
-          >
-            Index
-          </a>
+    <PageTransition>
+      <SidebarProvider
+        className='mx-auto min-h-0 max-w-[1320px] gap-10 px-5 md:px-8 print:block'
+        style={{ '--sidebar-width': '14rem' } as React.CSSProperties}
+      >
+        <Sidebar className='sticky top-18 bottom-auto h-[calc(100svh-4.5rem)] pr-4 pb-10 group-data-[collapsible=offcanvas]:w-0 group-data-[collapsible=offcanvas]:overflow-hidden group-data-[collapsible=offcanvas]:pr-0 data-[side=left]:left-auto data-[side=left]:border-r-0'>
+          <SidebarContent className='scroll-py-4 overscroll-contain py-8 md:mask-[linear-gradient(to_bottom,transparent,black_12px,black_calc(100%-12px),transparent)]'>
+            <DocsNavigation entries={entries} />
+          </SidebarContent>
+        </Sidebar>
+        <div className='min-w-0 flex-1'>
+          <div className='mt-4 mb-6 flex items-center gap-2 md:hidden print:hidden'>
+            <SidebarTrigger className='size-10' aria-label='Open documentation menu' />
+            <span className='text-sm'>Documentation</span>
+            <a
+              href='/docs'
+              className='text-muted-foreground ml-auto text-xs underline underline-offset-4'
+            >
+              Index
+            </a>
+          </div>
+          <div className='flex gap-10 print:block'>{children}</div>
         </div>
-        <div className='flex gap-10 print:block'>{children}</div>
-      </div>
-    </SidebarProvider>
+      </SidebarProvider>
+    </PageTransition>
   );
 }

--- a/site/src/docs/navigation.tsx
+++ b/site/src/docs/navigation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useSyncExternalStore } from 'react';
+import { useEffect } from 'react';
 
 import {
   SidebarGroup,
@@ -11,24 +11,11 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from '../components/ui/sidebar';
+import { usePathname } from '../hooks/use-pathname';
 import type { DocEntry } from './model';
 
-function subscribe(callback: () => void) {
-  const navigation = window.navigation;
-  navigation?.addEventListener('currententrychange', callback);
-  return () => navigation?.removeEventListener('currententrychange', callback);
-}
-
-function getPathname() {
-  return window.location.pathname;
-}
-
-function getServerPathname() {
-  return null;
-}
-
 export function DocsNavigation({ entries }: { readonly entries: ReadonlyArray<DocEntry> }) {
-  const pathname = useSyncExternalStore(subscribe, getPathname, getServerPathname);
+  const pathname = usePathname();
   const { setOpenMobile } = useSidebar();
   useEffect(() => {
     const navigation = window.navigation;
@@ -62,6 +49,7 @@ export function DocsNavigation({ entries }: { readonly entries: ReadonlyArray<Do
                     render={
                       <a
                         href={page.href}
+                        data-ersc-transition-types='docs-jump'
                         aria-current={page.href === currentHref ? 'page' : undefined}
                       >
                         {page.href.split('/').length <= 3 ? 'Overview' : page.title}

--- a/site/src/docs/page.tsx
+++ b/site/src/docs/page.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { Fragment } from 'react';
 
 import { PageMetadata } from '../components/page-metadata';
+import { PageTransition } from '../components/page-transition';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -40,7 +41,7 @@ export function DocumentationPage({
   );
   const breadcrumbs = page.kind === 'Example' ? [...ancestors, page] : ancestors;
   return (
-    <>
+    <PageTransition key={page.href}>
       <PageMetadata
         title={
           page.href === '/docs' ? 'Documentation · effective-rsc' : `${page.title} · effective-rsc`
@@ -66,7 +67,7 @@ export function DocumentationPage({
                           {entry.href === '/docs' ? 'Docs' : entry.title}
                         </BreadcrumbPage>
                       ) : (
-                        <BreadcrumbLink href={entry.href}>
+                        <BreadcrumbLink href={entry.href} data-ersc-transition-types='docs-jump'>
                           {entry.href === '/docs' ? 'Docs' : entry.title}
                         </BreadcrumbLink>
                       )}
@@ -90,6 +91,7 @@ export function DocumentationPage({
           ) : (
             <a
               href={previous.href}
+              data-ersc-transition-types='docs-previous'
               className={buttonVariants({
                 variant: 'ghost',
                 className:
@@ -106,6 +108,7 @@ export function DocumentationPage({
           {next !== undefined && (
             <a
               href={next.href}
+              data-ersc-transition-types='docs-next'
               className={buttonVariants({
                 variant: 'ghost',
                 className:
@@ -121,6 +124,6 @@ export function DocumentationPage({
           )}
         </nav>
       </div>
-    </>
+    </PageTransition>
   );
 }

--- a/site/src/home.tsx
+++ b/site/src/home.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, ArrowUpRight } from 'lucide-react';
 
 import { CodeBlock } from './components/code-block';
 import { PageMetadata } from './components/page-metadata';
+import { PageTransition } from './components/page-transition';
 import { buttonVariants } from './components/ui/button';
 import { DocumentationError } from './docs/files';
 import { readRequiredDocument } from './docs/service';
@@ -47,7 +48,7 @@ const HomeExample = ERSC.Component.make({
 
 export function Home() {
   return (
-    <>
+    <PageTransition>
       <PageMetadata
         title='effective-rsc · React Server Components with Effect and Bun'
         description='An Effect-native React Server Components framework for Bun. Explicit routes, request-scoped services, streaming, and native Server Functions.'
@@ -166,6 +167,6 @@ export function Home() {
           ))}
         </section>
       </div>
-    </>
+    </PageTransition>
   );
 }

--- a/site/src/hooks/use-pathname.ts
+++ b/site/src/hooks/use-pathname.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+function subscribe(callback: () => void) {
+  const navigation = window.navigation;
+  navigation?.addEventListener('currententrychange', callback);
+  return () => navigation?.removeEventListener('currententrychange', callback);
+}
+
+function getPathname() {
+  return window.location.pathname;
+}
+
+function getServerPathname() {
+  return null;
+}
+
+export function usePathname() {
+  return useSyncExternalStore(subscribe, getPathname, getServerPathname);
+}

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -37,6 +37,11 @@
 }
 
 :root {
+  --transition-enter: 210ms;
+  --transition-exit: 140ms;
+  --transition-move: var(--transition-enter);
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
   color-scheme: light;
   --background: oklch(1 0 0);
   --foreground: oklch(0.147 0 0);
@@ -83,5 +88,82 @@
 @layer base {
   * {
     border-color: var(--border);
+  }
+}
+
+::view-transition-old(root) {
+  animation-duration: var(--transition-exit);
+}
+
+::view-transition-old(.navigation-forward) {
+  --transition-offset: -2rem;
+  animation:
+    var(--transition-exit) var(--ease-out) both view-transition-fade-out,
+    var(--transition-move) var(--ease-in-out) both view-transition-slide reverse;
+}
+
+::view-transition-new(.navigation-forward) {
+  --transition-offset: 2rem;
+  animation:
+    var(--transition-enter) var(--ease-out) both view-transition-fade,
+    var(--transition-move) var(--ease-in-out) both view-transition-slide;
+}
+
+/* Previous links also carry navigation-forward from their history push. */
+::view-transition-old(.navigation-backward) {
+  --transition-offset: 2rem;
+  animation:
+    var(--transition-exit) var(--ease-out) both view-transition-fade-out,
+    var(--transition-move) var(--ease-in-out) both view-transition-slide reverse;
+}
+
+::view-transition-new(.navigation-backward) {
+  --transition-offset: -2rem;
+  animation:
+    var(--transition-enter) var(--ease-out) both view-transition-fade,
+    var(--transition-move) var(--ease-in-out) both view-transition-slide;
+}
+
+/* Unordered docs links take precedence over either history direction. */
+::view-transition-old(.navigation-jump) {
+  animation: var(--transition-exit) var(--ease-out) both view-transition-fade-out;
+}
+
+::view-transition-new(.navigation-jump) {
+  animation: var(--transition-enter) var(--ease-out) both view-transition-fade;
+}
+
+@keyframes view-transition-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes view-transition-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes view-transition-slide {
+  from {
+    translate: var(--transition-offset);
+  }
+  to {
+    translate: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
   }
 }


### PR DESCRIPTION
Native link navigations can now add application transition types through `data-ersc-transition-types`. The router captures them when navigation starts and publishes them alongside ERSC's built-in types; only ERSC-owned names are reserved, and link metadata is not replayed on Back/Forward.

The site uses these types for directional Previous/Next transitions and neutral sidebar navigation, preserves reduced-motion preferences, and isolates the sticky header's snapshot to keep scrolling content underneath it. Adds Vercel Analytics and Speed Insights, with pageviews tracking Navigation API commits.

Documents the attribute and defers typed navigation helpers until public client APIs are designed.

Validation: root check and build; 225 framework tests and 38 site tests; native-link browser tests in development and production; desktop/mobile motion and header-stacking checks in Chromium, including light/dark themes and reduced motion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom View Transition types on native links using `data-ersc-transition-types`.
  - Added animated page and documentation navigation, including forward, backward, and documentation jump transitions.
  - Added reduced-motion styling for supported transitions.
  - Added site analytics and performance insights.

- **Documentation**
  - Documented custom application transition types, reserved names, navigation behavior, and usage examples.

- **Tests**
  - Added coverage confirming transition types apply once and are not replayed during history navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->