### PR TITLE
fix: preserve HTTP request scope when providing application services

### DIFF
--- a/packages/effective-rsc/src/server/application.ts
+++ b/packages/effective-rsc/src/server/application.ts
@@ -251,11 +251,11 @@ const httpLayer = <Services, ApplicationError>(
 
   const RequestLayer = Layer.mergeAll(RenderersLayer, applicationState.layer);
   const ApplicationRoutesLayer = Layer.unwrap(
-    Effect.map(Effect.context<Services | FlightRenderer | HtmlRenderer>(), (requestContext) => {
+    Effect.map(Layer.build(RequestLayer), (applicationServices) => {
       const RequestContextMiddleware = HttpRouter.middleware<{
         provides: Services | FlightRenderer | HtmlRenderer;
       }>()((httpEffect): Effect.Effect<HttpServerResponse.HttpServerResponse, Types.unhandled> =>
-        httpEffect.pipe(Effect.provideContext(requestContext)),
+        httpEffect.pipe(Effect.provideContext(applicationServices)),
       );
       const makeRouteLayer = (destination: CompiledDestination<Services>) => {
         const GetLayer = HttpRouter.add('GET', destination.pattern, (request) =>
@@ -299,7 +299,7 @@ const httpLayer = <Services, ApplicationError>(
         ...remainingDestinations.map(makeRouteLayer),
       );
     }),
-  ).pipe(Layer.provide(RequestLayer));
+  );
 
   return Layer.mergeAll(StaticAssetsLayer, PublicAssetsLayer).pipe(
     Layer.provideMerge(ApplicationRoutesLayer),

--- a/packages/effective-rsc/tests/server/application.test.tsx
+++ b/packages/effective-rsc/tests/server/application.test.tsx
@@ -238,6 +238,55 @@ const progressiveServerFnRequest = (body: FormData) =>
   });
 
 describe('ServerApplication.httpLayer', () => {
+  it.effect(
+    'releases route middleware resources when the response finishes, before server shutdown',
+    () =>
+      Effect.gen(function* () {
+        const events: Array<string> = [];
+        const ERSC = Application.ersc();
+        const ResourceMiddleware = ERSC.Middleware.make(() =>
+          Effect.acquireRelease(
+            Effect.sync(() => {
+              events.push('acquired');
+            }),
+            () =>
+              Effect.sync(() => {
+                events.push('released');
+              }),
+          ).pipe(Effect.as(HttpServerResponse.text('response'))),
+        );
+        const RootLayout = ERSC.Layout.make({
+          render: ({ children }) => Effect.succeed(<html lang='en'>{children}</html>),
+        });
+        const Page = ERSC.Page.make({
+          render: () => Effect.die('Resource middleware should answer without rendering the Page.'),
+        });
+        const App = ERSC.make({
+          routes: ERSC.withMiddleware(ResourceMiddleware)
+            .Routes.make({ layout: RootLayout })
+            .page('/', Page),
+        });
+        const { handler, dispose } = HttpRouter.toWebHandler(
+          ServerApplication.httpLayer(App).pipe(
+            Layer.provide(ServerConfigLayer),
+            Layer.provide(
+              Layer.mergeAll(BunFileSystem.layer, BunHttpPlatform.layer, BunPath.layer),
+            ),
+          ),
+          { disableLogger: true },
+        );
+        yield* Effect.addFinalizer(() => Effect.promise(dispose));
+
+        const response = yield* Effect.promise(() => handler(new Request(`${Origin}/`)));
+        const body = yield* Effect.promise(() => response.text());
+
+        expect(response.status).toBe(200);
+        expect(body).toBe('response');
+        // Request cleanup must happen while the application is still running.
+        expect([...events]).toEqual(['acquired', 'released']);
+      }).pipe(Effect.scoped),
+  );
+
   it.effect('disables request logging for compiled assets only', () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;


### PR DESCRIPTION
Route middleware resources currently survive completed responses until application shutdown because ERSC copies the application Layer's scope into each request. Build the application/renderers Layer and provide its resulting service context so native HTTP requests retain their own cleanup scope.

Add a regression through the real `ServerApplication.httpLayer` that acquires a middleware resource, consumes the response, and asserts release before server shutdown. It failed before the fix and now passes.

Validation:

- `bun run check`
- `bun run build`
- `bun run test`: 334 unit tests and 99 browser tests passed; 13 existing skips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling so route middleware resources are reliably released when a response completes.
  * Ensured middleware cleanup occurs before server shutdown, helping prevent resource leaks and improving graceful request lifecycle management.

* **Tests**
  * Added integration coverage validating middleware acquisition and release ordering, including responses that bypass page rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->