### PR TITLE
fix: preserve visible refresh streams during navigation

### DIFF
--- a/docs/architecture/client-router.md
+++ b/docs/architecture/client-router.md
@@ -217,7 +217,7 @@ delivers its supersession abort.
 
 ## Renderer interface
 
-Navigation publication returns only UI lifecycle facts:
+Navigation and refresh publication return only UI lifecycle facts:
 
 ```ts
 type RendererNavigation = {
@@ -230,6 +230,9 @@ type RendererNavigation = {
 - `committed` resolves from the framework root's layout effect after the render becomes visible.
 - `retired` resolves when any different render commits and the navigation tree is no longer visible.
 - `discard` is legal only before commit and resolves once the scheduled tree cannot commit.
+
+Refresh cancellation may race with its UI commit. A refresh's `discard` therefore leaves an
+already-visible tree intact and waits for its retirement instead.
 
 The router must finish `discard` before releasing that candidate's Flight resource. The renderer
 does not expose Flight completion, a stable-tree snapshot, history rollback, or navigation status.
@@ -289,8 +292,10 @@ postcommit Flight lifetime or a global busy flag.
 - A visible navigation stream may coexist with a route refresh or Server Function request.
 - A different successful renderer commit retires the visible navigation regardless of its source.
 - A failed refresh leaves the visible navigation and its stream intact.
-- A routed navigation may preempt an in-progress refresh through the existing render race; the
-  router does not serialize them.
+- A routed navigation may preempt refresh preparation. Published refreshes retain their response
+  scope in the browser runtime until EOF or renderer-confirmed retirement. Cancelling a pending
+  refresh requests a discard before releasing its response; cancelling a committed refresh leaves
+  its visible stream intact. The router does not serialize refreshes and navigations.
 
 ## Verification contract
 

--- a/docs/architecture/lifetimes-and-protocols.md
+++ b/docs/architecture/lifetimes-and-protocols.md
@@ -21,6 +21,7 @@ Bun server scope
 | Authored render Effects            | Request render-runtime FiberSet | Flight completion or request interruption              |
 | Preparing browser navigation       | Client-router candidate         | First UI commit, native abort, or supersession         |
 | Visible navigation Flight stream   | Client-router generation        | Flight EOF or renderer-confirmed retirement            |
+| Published current-route refresh    | Browser scope                   | Flight EOF, render retirement, or browser shutdown     |
 | Completed history-entry route tree | Browser route cache             | Cache invalidation or history-entry disposal           |
 
 Effect interruption and Web Stream cancellation propagate across these boundaries. Work is not

--- a/packages/effective-rsc/src/client/browser-renderer.ts
+++ b/packages/effective-rsc/src/client/browser-renderer.ts
@@ -8,26 +8,21 @@ export type BrowserRendererNavigation = {
   readonly retired: Promise<void>;
 };
 
-type BrowserRenderNavigationState = {
+type BrowserRenderUpdate = {
   readonly committed: PromiseWithResolvers<void>;
   readonly retired: PromiseWithResolvers<void>;
   readonly routeTree: RouteTreeModel;
 };
 
-type BrowserRenderNavigationPhase =
-  | 'Scheduled'
-  | 'DiscardRequested'
-  | 'Visible'
-  | 'Completed'
-  | 'Retired';
+type BrowserRenderPhase = 'Scheduled' | 'DiscardRequested' | 'Visible' | 'Completed' | 'Retired';
 
 type BrowserRenderOwner =
   | { readonly _tag: 'Stable' }
-  | { readonly _tag: 'Navigation'; readonly navigation: BrowserRenderNavigationState };
+  | { readonly _tag: 'Update'; readonly update: BrowserRenderUpdate };
 
 type BrowserRendererLifecycle = {
   active: BrowserRenderOwner;
-  readonly phases: WeakMap<BrowserRenderNavigationState, BrowserRenderNavigationPhase>;
+  readonly phases: WeakMap<BrowserRenderUpdate, BrowserRenderPhase>;
   stableRouteTree: RouteTreeModel;
   visible: BrowserRenderOwner;
 };
@@ -43,40 +38,29 @@ type BrowserRendererState =
 export type BrowserRender =
   | { readonly _tag: 'Initial'; readonly routeTree: RouteTreeModel }
   | {
-      readonly _tag: 'Navigation';
-      readonly navigation: BrowserRenderNavigationState;
+      readonly _tag: 'Navigation' | 'Refresh';
+      readonly update: BrowserRenderUpdate;
       readonly routeTree: RouteTreeModel;
     }
   | {
       readonly _tag: 'Discard';
-      readonly navigation: BrowserRenderNavigationState;
+      readonly update: BrowserRenderUpdate;
       readonly routeTree: RouteTreeModel;
       readonly visible: BrowserRenderOwner;
-    }
-  | {
-      readonly _tag: 'Refresh';
-      readonly committed: PromiseWithResolvers<void>;
-      readonly routeTree: RouteTreeModel;
     };
 
-const getNavigationPhase = (
-  lifecycle: BrowserRendererLifecycle,
-  navigation: BrowserRenderNavigationState,
-) => {
-  const phase = lifecycle.phases.get(navigation);
+const getRenderPhase = (lifecycle: BrowserRendererLifecycle, update: BrowserRenderUpdate) => {
+  const phase = lifecycle.phases.get(update);
   if (phase === undefined) {
-    throw new TypeError('Browser navigation does not belong to this root.');
+    throw new TypeError('Browser render does not belong to this root.');
   }
   return phase;
 };
 
-const retireNavigation = (
-  lifecycle: BrowserRendererLifecycle,
-  navigation: BrowserRenderNavigationState,
-) => {
-  if (getNavigationPhase(lifecycle, navigation) !== 'Retired') {
-    lifecycle.phases.set(navigation, 'Retired');
-    navigation.retired.resolve();
+const retireUpdate = (lifecycle: BrowserRendererLifecycle, update: BrowserRenderUpdate) => {
+  if (getRenderPhase(lifecycle, update) !== 'Retired') {
+    lifecycle.phases.set(update, 'Retired');
+    update.retired.resolve();
   }
 };
 
@@ -109,7 +93,7 @@ export class BrowserRenderer extends Context.Service<BrowserRenderer>()(
           _tag: 'Ready',
           lifecycle: {
             active: { _tag: 'Stable' },
-            phases: new WeakMap<BrowserRenderNavigationState, BrowserRenderNavigationPhase>(),
+            phases: new WeakMap<BrowserRenderUpdate, BrowserRenderPhase>(),
             stableRouteTree: initialRouteTree,
             visible: { _tag: 'Stable' },
           },
@@ -117,99 +101,89 @@ export class BrowserRenderer extends Context.Service<BrowserRenderer>()(
         });
       };
 
-      const navigate = (routeTree: RouteTreeModel) => {
+      const schedule = (routeTree: RouteTreeModel, kind: 'Navigation' | 'Refresh') => {
         const { lifecycle, publish } = getReadyState();
-        const navigation: BrowserRenderNavigationState = {
+        const update: BrowserRenderUpdate = {
           committed: Promise.withResolvers<void>(),
           retired: Promise.withResolvers<void>(),
           routeTree,
         };
-        lifecycle.phases.set(navigation, 'Scheduled');
-        lifecycle.active = { _tag: 'Navigation', navigation };
-        publish({ _tag: 'Navigation', navigation, routeTree: navigation.routeTree });
+        lifecycle.phases.set(update, 'Scheduled');
+        lifecycle.active = { _tag: 'Update', update };
+        publish({ _tag: kind, update, routeTree });
 
         return {
-          committed: navigation.committed.promise,
+          committed: update.committed.promise,
           discard: () => {
-            if (getNavigationPhase(lifecycle, navigation) !== 'Scheduled') {
+            if (getRenderPhase(lifecycle, update) !== 'Scheduled') {
+              // Refresh cancellation can arrive just after React commits. Its visible tree
+              // must survive until a successor commits, even if the caller has moved on.
+              if (kind === 'Refresh') {
+                return update.retired.promise;
+              }
               throw new TypeError('Only a scheduled browser navigation can be discarded.');
             }
-            lifecycle.phases.set(navigation, 'DiscardRequested');
-            if (
-              lifecycle.active._tag === 'Navigation' &&
-              lifecycle.active.navigation === navigation
-            ) {
+            lifecycle.phases.set(update, 'DiscardRequested');
+            if (lifecycle.active._tag === 'Update' && lifecycle.active.update === update) {
               const visible = lifecycle.visible;
               lifecycle.active =
-                visible._tag === 'Navigation' &&
-                getNavigationPhase(lifecycle, visible.navigation) === 'Visible'
+                visible._tag === 'Update' && getRenderPhase(lifecycle, visible.update) === 'Visible'
                   ? visible
                   : { _tag: 'Stable' };
             }
             publish({
               _tag: 'Discard',
-              navigation,
+              update,
               routeTree:
-                lifecycle.visible._tag === 'Navigation'
-                  ? lifecycle.visible.navigation.routeTree
+                lifecycle.visible._tag === 'Update'
+                  ? lifecycle.visible.update.routeTree
                   : lifecycle.stableRouteTree,
               visible: lifecycle.visible,
             });
-            return navigation.retired.promise;
+            return update.retired.promise;
           },
-          retired: navigation.retired.promise,
+          retired: update.retired.promise,
         };
       };
 
-      const refresh = (routeTree: RouteTreeModel) => {
-        const { lifecycle, publish } = getReadyState();
-        const committed = Promise.withResolvers<void>();
-        lifecycle.active = { _tag: 'Stable' };
-        publish({ _tag: 'Refresh', committed, routeTree });
-        return committed.promise;
-      };
+      const navigate = (routeTree: RouteTreeModel) => schedule(routeTree, 'Navigation');
+      const refresh = (routeTree: RouteTreeModel) => schedule(routeTree, 'Refresh');
 
       const commit = (render: BrowserRender) => {
         const { lifecycle } = getReadyState();
         const previousVisible = lifecycle.visible;
         const visible: BrowserRenderOwner =
-          render._tag === 'Navigation'
-            ? { _tag: 'Navigation', navigation: render.navigation }
+          render._tag === 'Navigation' || render._tag === 'Refresh'
+            ? { _tag: 'Update', update: render.update }
             : render._tag === 'Discard'
               ? render.visible
               : { _tag: 'Stable' };
         lifecycle.visible = visible;
 
         if (
-          previousVisible._tag === 'Navigation' &&
-          (visible._tag !== 'Navigation' || visible.navigation !== previousVisible.navigation)
+          previousVisible._tag === 'Update' &&
+          (visible._tag !== 'Update' || visible.update !== previousVisible.update)
         ) {
-          retireNavigation(lifecycle, previousVisible.navigation);
+          retireUpdate(lifecycle, previousVisible.update);
         }
 
         switch (render._tag) {
           case 'Initial':
             break;
           case 'Discard':
-            retireNavigation(lifecycle, render.navigation);
+            retireUpdate(lifecycle, render.update);
             break;
           case 'Navigation':
-            if (getNavigationPhase(lifecycle, render.navigation) === 'Scheduled') {
-              lifecycle.phases.set(render.navigation, 'Visible');
+          case 'Refresh':
+            if (getRenderPhase(lifecycle, render.update) === 'Scheduled') {
+              lifecycle.phases.set(render.update, 'Visible');
             }
-            if (
-              lifecycle.active._tag === 'Navigation' &&
-              lifecycle.active.navigation === render.navigation
-            ) {
+            if (lifecycle.active._tag === 'Update' && lifecycle.active.update === render.update) {
               lifecycle.active = { _tag: 'Stable' };
               lifecycle.stableRouteTree = render.routeTree;
-              lifecycle.phases.set(render.navigation, 'Completed');
+              lifecycle.phases.set(render.update, 'Completed');
             }
-            render.navigation.committed.resolve();
-            break;
-          case 'Refresh':
-            lifecycle.stableRouteTree = render.routeTree;
-            render.committed.resolve();
+            render.update.committed.resolve();
             break;
         }
       };

--- a/packages/effective-rsc/src/client/call-server.ts
+++ b/packages/effective-rsc/src/client/call-server.ts
@@ -138,23 +138,22 @@ export const installCallServer = Effect.gen(function* () {
       return;
     }
     const commitRefresh = routeLoader.prepareRefresh(resource.payload.routeTree);
-    let renderCommitted!: Promise<void>;
+    let published!: ReturnType<BrowserRenderer['Service']['refresh']>;
     yield* Effect.sync(() => {
       startTransition(() => {
         addTransitionType('server-function');
         // Do not return the commit Promise from React's Transition Action. React cannot commit the
         // render until that Action ends.
-        renderCommitted = browserRenderer.refresh(resource.payload.routeTree).committed;
+        published = browserRenderer.refresh(resource.payload.routeTree);
       });
     });
-    yield* Effect.all([resource.completed, Effect.promise(() => renderCommitted)], {
-      concurrency: 'unbounded',
-      discard: true,
-    }).pipe(
-      Effect.andThen(Effect.sync(commitRefresh)),
-      Effect.onError(() => resource.release),
-      Effect.forkScoped,
-    );
+    yield* Effect.raceFirst(
+      Effect.all([resource.completed, Effect.promise(() => published.committed)], {
+        concurrency: 'unbounded',
+        discard: true,
+      }).pipe(Effect.andThen(Effect.sync(commitRefresh))),
+      Effect.promise(() => published.retired),
+    ).pipe(Effect.ensuring(resource.release), Effect.forkScoped({ startImmediately: true }));
   });
 
   yield* Effect.sync(() => {

--- a/packages/effective-rsc/src/client/call-server.ts
+++ b/packages/effective-rsc/src/client/call-server.ts
@@ -144,7 +144,7 @@ export const installCallServer = Effect.gen(function* () {
         addTransitionType('server-function');
         // Do not return the commit Promise from React's Transition Action. React cannot commit the
         // render until that Action ends.
-        renderCommitted = browserRenderer.refresh(resource.payload.routeTree);
+        renderCommitted = browserRenderer.refresh(resource.payload.routeTree).committed;
       });
     });
     yield* Effect.all([resource.completed, Effect.promise(() => renderCommitted)], {

--- a/packages/effective-rsc/src/client/route-refresh.ts
+++ b/packages/effective-rsc/src/client/route-refresh.ts
@@ -1,12 +1,10 @@
-import { Context, Effect, FiberMap, Layer, Ref } from 'effect';
+import { Context, Effect, Exit, FiberHandle, Layer, Ref, Scope } from 'effect';
 import { addTransitionType, startTransition } from 'react';
 
 import { BrowserRenderer } from './browser-renderer';
 import { NavigationApi } from './navigation-api';
 import { isRoutedNavigation, preserveRequestedHash } from './navigation-routing';
 import { RouteLoader } from './route-loader';
-
-const CurrentRouteRefreshKey = 'CurrentRouteRefresh';
 
 export type RouteRefreshTransitionType = 'hmr-refresh' | 'server-function';
 
@@ -55,7 +53,8 @@ export const installRouteRefresh = Effect.gen(function* () {
   const navigationApi = yield* NavigationApi;
   const routeLoader = yield* RouteLoader;
   const routeRefresher = yield* RouteRefresher;
-  const refreshes = yield* FiberMap.make<typeof CurrentRouteRefreshKey>();
+  const refreshes = yield* FiberHandle.make<void>();
+  const browserScope = yield* Effect.scope;
 
   const waitForNavigationIdle = Effect.suspend(() => {
     const transition = navigationApi.getTransition();
@@ -80,41 +79,75 @@ export const installRouteRefresh = Effect.gen(function* () {
   });
 
   const refreshRoute = Effect.fnUntraced(function* (transitionType: RouteRefreshTransitionType) {
-    const currentEntry = navigationApi.getCurrentEntry();
-    const destination = new URL(currentEntry?.url ?? navigationApi.getCurrentUrl());
-    const resource = yield* routeLoader.load({
-      destination: {
-        id: currentEntry?.id ?? '',
-        url: destination.href,
-      },
-      navigationType: 'replace',
-    });
+    const responseScope = yield* Scope.make();
+    const render = yield* Effect.uninterruptibleMask(
+      Effect.fnUntraced(
+        function* (restore) {
+          const currentEntry = navigationApi.getCurrentEntry();
+          const destination = new URL(currentEntry?.url ?? navigationApi.getCurrentUrl());
+          const resource = yield* restore(
+            routeLoader
+              .load({
+                destination: {
+                  id: currentEntry?.id ?? '',
+                  url: destination.href,
+                },
+                navigationType: 'replace',
+              })
+              .pipe(Scope.provide(responseScope)),
+          );
+          const release = resource.release.pipe(Scope.use(responseScope));
 
-    if (resource._tag === 'Document') {
-      yield* resource.release;
-      yield* Effect.sync(navigationApi.reloadDocument);
-      return;
+          if (resource._tag === 'Document') {
+            yield* release;
+            yield* Effect.sync(navigationApi.reloadDocument);
+            return;
+          }
+
+          const resolvedDestination = preserveRequestedHash(destination, resource.resolvedUrl);
+          if (resolvedDestination.href !== destination.href) {
+            yield* release;
+            yield* Effect.sync(() => navigationApi.replaceDocument(resolvedDestination.href));
+            return;
+          }
+
+          const commitRefresh = routeLoader.prepareRefresh(resource.routeTree);
+          let published!: ReturnType<BrowserRenderer['Service']['refresh']>;
+          yield* Effect.sync(() => {
+            startTransition(() => {
+              addTransitionType(transitionType);
+              published = browserRenderer.refresh(resource.routeTree);
+            });
+          });
+          // Finish publication and install its browser-owned lifetime before allowing cancellation.
+          yield* Effect.raceFirst(
+            Effect.all([Effect.promise(() => published.committed), resource.completed], {
+              concurrency: 'unbounded',
+              discard: true,
+            }).pipe(Effect.andThen(Effect.sync(commitRefresh))),
+            Effect.promise(() => published.retired),
+          ).pipe(
+            Effect.ensuring(release),
+            Effect.catch((cause) =>
+              Effect.logError('Failed to stream the refreshed route.', cause),
+            ),
+            Effect.forkIn(browserScope, { startImmediately: true }),
+          );
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              // The stream fiber awaits retirement; waiting here could block the replacement render.
+              void published.discard();
+            }),
+          );
+          return published;
+        },
+        Effect.onError((cause) => Scope.close(responseScope, Exit.failCause(cause))),
+      ),
+    );
+
+    if (render !== undefined) {
+      yield* Effect.promise(() => render.committed);
     }
-
-    const resolvedDestination = preserveRequestedHash(destination, resource.resolvedUrl);
-    if (resolvedDestination.href !== destination.href) {
-      yield* resource.release;
-      yield* Effect.sync(() => navigationApi.replaceDocument(resolvedDestination.href));
-      return;
-    }
-
-    const commitRefresh = routeLoader.prepareRefresh(resource.routeTree);
-    let renderCommitted!: Promise<void>;
-    yield* Effect.sync(() => {
-      startTransition(() => {
-        addTransitionType(transitionType);
-        renderCommitted = browserRenderer.refresh(resource.routeTree);
-      });
-    });
-    yield* Effect.all([Effect.promise(() => renderCommitted), resource.completed], {
-      concurrency: 'unbounded',
-      discard: true,
-    }).pipe(Effect.andThen(Effect.sync(commitRefresh)), Effect.ensuring(resource.release));
   });
 
   const refreshCurrentRoute = Effect.fnUntraced(
@@ -130,10 +163,8 @@ export const installRouteRefresh = Effect.gen(function* () {
   );
 
   yield* routeRefresher.replace({
-    interruptCurrentRouteRefresh: FiberMap.remove(refreshes, CurrentRouteRefreshKey),
+    interruptCurrentRouteRefresh: FiberHandle.clear(refreshes),
     refreshCurrentRoute: (transitionType) =>
-      FiberMap.run(refreshes, CurrentRouteRefreshKey, refreshCurrentRoute(transitionType)).pipe(
-        Effect.asVoid,
-      ),
+      FiberHandle.run(refreshes, refreshCurrentRoute(transitionType)).pipe(Effect.asVoid),
   });
 });

--- a/packages/effective-rsc/tests/client/browser-renderer.test.ts
+++ b/packages/effective-rsc/tests/client/browser-renderer.test.ts
@@ -109,7 +109,7 @@ it.effect('retires a visible navigation when a refresh commits', () =>
     expect(retirementObserved).toBe(false);
 
     renderer.commit(refreshRender);
-    yield* Effect.promise(() => Promise.all([navigation.retired, refresh]));
+    yield* Effect.promise(() => Promise.all([navigation.retired, refresh.committed]));
 
     expect(retirementObserved).toBe(true);
   }).pipe(Effect.provide(BrowserRenderer.layer)),
@@ -199,7 +199,7 @@ it.effect('uses a committed Server Function refresh as the next discard target',
       return yield* Effect.die('Expected a refresh render.');
     }
     renderer.commit(refreshRender);
-    yield* Effect.promise(() => refreshed);
+    yield* Effect.promise(() => refreshed.committed);
 
     const navigation = renderer.navigate(makeRouteTree('destination'));
     const navigationRender = nextRender(renders);

--- a/packages/effective-rsc/tests/client/call-server.test.ts
+++ b/packages/effective-rsc/tests/client/call-server.test.ts
@@ -4,7 +4,7 @@ import { HttpClient } from 'effect/unstable/http';
 import { vi } from 'vitest';
 
 import { BrowserEffectRunner } from '../../src/client/browser-effect-runner';
-import { BrowserRenderer } from '../../src/client/browser-renderer';
+import { type BrowserRender, BrowserRenderer } from '../../src/client/browser-renderer';
 import { FlightClient } from '../../src/client/flight-client';
 import { NavigationApi } from '../../src/client/navigation-api';
 import { RouteLoader } from '../../src/client/route-loader';
@@ -392,6 +392,66 @@ it.effect('does not let an older invocation response overwrite a newer response'
         HttpClient.HttpClient,
         HttpClient.make(() => Effect.die('Unexpected HTTP request.')),
       ),
+    ),
+  ),
+);
+
+it.effect('releases a visible Server Function refresh when its replacement commits', () =>
+  Effect.gen(function* () {
+    const browserRenderer = yield* BrowserRenderer.make;
+    let published = Promise.withResolvers<BrowserRender>();
+    browserRenderer.initialize(makeRouteTree('initial'), (render) => published.resolve(render));
+    const released = vi.fn();
+    const cached = vi.fn();
+    yield* listen(
+      Layer.mergeAll(
+        BrowserEffectRunner.layer,
+        BrowserRenderer.layerTest(browserRenderer),
+        FlightClient.layerTest({
+          load: () =>
+            Effect.succeed({
+              ...makeFlight('refreshed', 'saved', Effect.sync(released)),
+              completed: Effect.never,
+            }),
+        }),
+        NavigationApi.layerTest({
+          getCurrentEntry: () => firstEntry,
+          getCurrentUrl: () => firstEntry.url,
+          getTransition: () => null,
+          navigate: () => {
+            throw new TypeError('Unexpected document navigation.');
+          },
+          reloadDocument: () => undefined,
+          replaceDocument: () => undefined,
+          subscribe: () => () => undefined,
+        }),
+        RouteLoader.layerTest({ invalidate: () => undefined, prepareRefresh: () => cached }),
+        RouteRefresher.layerTest({ interruptCurrentRouteRefresh: Effect.void }),
+      ),
+    );
+
+    const result = yield* Effect.promise(() => invokeServerFn('save'));
+    expect(result).toBe('saved');
+    const refresh = yield* Effect.promise(() => published.promise);
+    browserRenderer.commit(refresh);
+
+    // The refreshed page is still streaming while its replacement prepares.
+    published = Promise.withResolvers<BrowserRender>();
+    const replacement = browserRenderer.navigate(makeRouteTree('replacement'));
+    const nextRender = yield* Effect.promise(() => published.promise);
+    yield* Effect.yieldNow;
+    expect(released).not.toHaveBeenCalled();
+
+    browserRenderer.commit(nextRender);
+    yield* Effect.promise(() => replacement.committed);
+    yield* Effect.yieldNow;
+    expect(released).toHaveBeenCalledOnce();
+    expect(cached).not.toHaveBeenCalled();
+  }).pipe(
+    Effect.scoped,
+    Effect.provideService(
+      HttpClient.HttpClient,
+      HttpClient.make(() => Effect.die('Unexpected HTTP request.')),
     ),
   ),
 );

--- a/packages/effective-rsc/tests/client/call-server.test.ts
+++ b/packages/effective-rsc/tests/client/call-server.test.ts
@@ -136,7 +136,9 @@ it.effect('releases an incomplete Server Function response', () =>
             navigate: () => {
               throw new TypeError('Unexpected navigation render.');
             },
-            refresh: () => Promise.reject(new TypeError('Unexpected route refresh.')),
+            refresh: () => {
+              throw new TypeError('Unexpected route refresh.');
+            },
           }),
           flightClientLayer,
           navigationApiLayer,
@@ -177,7 +179,9 @@ const staleResponseScenario = (
       const currentRouteRefresh = yield* Deferred.make<void>();
       const refreshTransitionTypes: Array<string> = [];
       const released = vi.fn();
-      const rendered = vi.fn(() => Promise.resolve());
+      const rendered = vi.fn(() => {
+        throw new TypeError('Unexpected response render.');
+      });
       const navigationState: TestNavigationState = {
         currentEntry: MutableRef.make(firstEntry),
         transition: MutableRef.make(null),
@@ -327,7 +331,11 @@ it.effect('does not let an older invocation response overwrite a newer response'
         },
         refresh: (routeTree) => {
           rendered.push(routeTree.id);
-          return Promise.resolve();
+          return {
+            committed: Promise.resolve(),
+            retired: Promise.withResolvers<void>().promise,
+            discard: () => Promise.resolve(),
+          };
         },
       });
       const routeLoaderLayer = RouteLoader.layerTest({

--- a/packages/effective-rsc/tests/client/client-router.test.ts
+++ b/packages/effective-rsc/tests/client/client-router.test.ts
@@ -251,7 +251,11 @@ const makeBrowserRenderer = (renders: Array<BrowserRenderRequest> = []) => {
       const previousNavigation = visibleNavigation;
       visibleNavigation = null;
       renders.push({ _tag: 'ServerFunction', routeTree });
-      return Promise.resolve().then(() => previousNavigation?.resolve());
+      return {
+        committed: Promise.resolve().then(() => previousNavigation?.resolve()),
+        retired: Promise.withResolvers<void>().promise,
+        discard: () => Promise.resolve(),
+      };
     },
   });
 };
@@ -968,7 +972,9 @@ it.effect('cancels a streaming Flight response abandoned before React commits', 
             retired: Promise.resolve(),
           };
         },
-        refresh: () => Promise.resolve(),
+        refresh: () => {
+          throw new TypeError('Unexpected refresh.');
+        },
       });
       const httpClient = HttpClient.make((request, _url, signal) =>
         Effect.sync(() => {
@@ -1115,7 +1121,9 @@ it.effect('discards and releases a scheduled candidate when a newer navigation s
             retired: Promise.resolve(),
           };
         },
-        refresh: () => Promise.resolve(),
+        refresh: () => {
+          throw new TypeError('Unexpected refresh.');
+        },
       });
       const httpClient = HttpClient.make((request, _url, signal) =>
         Effect.sync(() => {
@@ -1243,7 +1251,9 @@ it.effect('retains a committed Flight response until its render retires', () => 
           discard: () => Promise.resolve(),
           retired: renderRetired.promise,
         }),
-        refresh: () => Promise.resolve(),
+        refresh: () => {
+          throw new TypeError('Unexpected refresh.');
+        },
       });
       yield* listen(navigation, browserRenderer, httpClient);
       const pendingNavigation = makeNavigationEvent({ signal: navigationAbort.signal });

--- a/packages/effective-rsc/tests/client/route-refresh.test.ts
+++ b/packages/effective-rsc/tests/client/route-refresh.test.ts
@@ -28,12 +28,18 @@ vi.mock('react', (importOriginal) =>
 );
 
 import { BrowserEffectRunner } from '../../src/client/browser-effect-runner';
-import { BrowserRenderer } from '../../src/client/browser-renderer';
+import { type BrowserRender, BrowserRenderer } from '../../src/client/browser-renderer';
 import { FlightLoadError } from '../../src/client/flight-client';
 import { NavigationApi } from '../../src/client/navigation-api';
 import { RouteLoader } from '../../src/client/route-loader';
 import { installRouteRefresh, RouteRefresher } from '../../src/client/route-refresh';
 import type { RouteTreeModel } from '../../src/rsc/route-tree';
+
+const committedRefresh = () => ({
+  committed: Promise.resolve(),
+  retired: Promise.withResolvers<void>().promise,
+  discard: () => Promise.resolve(),
+});
 
 const makeRouteTree = (id: string): RouteTreeModel => ({ child: null, content: null, id });
 
@@ -194,7 +200,7 @@ it.effect('applies the HMR transition type after the active navigation settles',
       },
       refresh: (nextRouteTree) => {
         rendered.resolve(nextRouteTree);
-        return Promise.resolve();
+        return committedRefresh();
       },
     });
 
@@ -226,7 +232,7 @@ it.effect('leaves the current render untouched when refresh loading fails', () =
   Effect.gen(function* () {
     const navigation = new TestNavigation();
     const loadFinished = yield* Deferred.make<void>();
-    const renderRefresh = vi.fn(() => Promise.resolve());
+    const renderRefresh = vi.fn(committedRefresh);
     const routeLoader = RouteLoader.of({
       invalidate: vi.fn(),
       load: () =>
@@ -262,12 +268,15 @@ it.effect('interrupts a current-route refresh when a routed navigation begins', 
     const navigation = new TestNavigation();
     const loadStarted = yield* Deferred.make<void>();
     const loadInterrupted = yield* Deferred.make<void>();
-    const rootRefresh = vi.fn(() => Promise.resolve());
+    const responseScopeClosed = yield* Deferred.make<void>();
+    const rootRefresh = vi.fn(committedRefresh);
     const cached = vi.fn();
     const routeLoader = RouteLoader.of({
       invalidate: vi.fn(),
       load: () =>
-        Deferred.succeed(loadStarted, undefined).pipe(
+        Effect.acquireRelease(Deferred.succeed(loadStarted, undefined), () =>
+          Deferred.succeed(responseScopeClosed, undefined),
+        ).pipe(
           Effect.andThen(Effect.never),
           Effect.onInterrupt(() => Deferred.succeed(loadInterrupted, undefined)),
         ),
@@ -289,6 +298,7 @@ it.effect('interrupts a current-route refresh when a routed navigation begins', 
         yield* Deferred.await(loadStarted);
         navigation.dispatchEvent(routedNavigation());
         yield* Deferred.await(loadInterrupted);
+        yield* Deferred.await(responseScopeClosed);
 
         expect(rootRefresh).not.toHaveBeenCalled();
         expect(cached).not.toHaveBeenCalled();
@@ -297,12 +307,231 @@ it.effect('interrupts a current-route refresh when a routed navigation begins', 
   }),
 );
 
+const makeStreamingRefresh = Effect.gen(function* () {
+  const streamFinished = yield* Deferred.make<void>();
+  const streamReleased = yield* Deferred.make<void>();
+  const responseScopeClosed = yield* Deferred.make<void>();
+  const releaseStream = vi.fn();
+  const cached = vi.fn();
+  const refreshedTree = makeRouteTree('refreshed');
+  const routeLoader = RouteLoader.of({
+    invalidate: vi.fn(),
+    load: () =>
+      Effect.acquireRelease(
+        Effect.succeed({
+          _tag: 'Route' as const,
+          cache: () => undefined,
+          completed: Deferred.await(streamFinished),
+          release: Effect.sync(releaseStream).pipe(
+            Effect.andThen(Deferred.succeed(streamReleased, undefined)),
+          ),
+          resolvedUrl: new URL(entry.url),
+          routeTree: refreshedTree,
+        }),
+        () => Deferred.succeed(responseScopeClosed, undefined),
+      ),
+    loadInitial: Effect.die('Unexpected initial route load.'),
+    prepareRefresh: () => cached,
+  });
+  return {
+    routeLoader,
+    refreshedTree,
+    streamFinished,
+    streamReleased,
+    responseScopeClosed,
+    releaseStream,
+    cached,
+  };
+});
+
+it.effect('keeps a visible refresh stream open while the next navigation is pending', () =>
+  Effect.gen(function* () {
+    const navigation = new TestNavigation();
+    const browserRenderer = yield* BrowserRenderer.make;
+    const published = Promise.withResolvers<BrowserRender>();
+    browserRenderer.initialize(makeRouteTree('initial'), published.resolve);
+
+    const {
+      routeLoader,
+      refreshedTree,
+      streamFinished,
+      streamReleased,
+      responseScopeClosed,
+      releaseStream,
+    } = yield* makeStreamingRefresh;
+
+    yield* withBrowserRefresh(navigation, browserRenderer, routeLoader, (refresh) =>
+      Effect.gen(function* () {
+        // Commit the refreshed page while its server response is still streaming.
+        yield* refresh('server-function');
+        const render = yield* Effect.promise(() => published.promise);
+        expect(render._tag).toBe('Refresh');
+        expect(render.routeTree).toBe(refreshedTree);
+        browserRenderer.commit(render);
+        yield* Effect.yieldNow;
+        expect(releaseStream).not.toHaveBeenCalled();
+        expect(Deferred.isDoneUnsafe(responseScopeClosed)).toBe(false);
+
+        // Navigation starts, but the refreshed page stays visible until its replacement commits.
+        const nextNavigation = Promise.withResolvers<void>();
+        navigation.transition = {
+          committed: nextNavigation.promise,
+          finished: nextNavigation.promise,
+          from: entry,
+          navigationType: 'push',
+        };
+        navigation.dispatchEvent(routedNavigation());
+        yield* Effect.yieldNow;
+
+        expect(releaseStream).not.toHaveBeenCalled();
+        expect(Deferred.isDoneUnsafe(responseScopeClosed)).toBe(false);
+
+        // The visible page can finish streaming; only then may its response be released.
+        yield* Deferred.succeed(streamFinished, undefined);
+        yield* Deferred.await(streamReleased);
+        yield* Deferred.await(responseScopeClosed);
+        expect(releaseStream).toHaveBeenCalledOnce();
+      }),
+    );
+  }),
+);
+
+it.effect('releases a streaming refresh when its replacement becomes visible', () =>
+  Effect.gen(function* () {
+    const navigation = new TestNavigation();
+    const browserRenderer = yield* BrowserRenderer.make;
+    let published = Promise.withResolvers<BrowserRender>();
+    browserRenderer.initialize(makeRouteTree('initial'), (render) => published.resolve(render));
+    const { routeLoader, streamReleased, responseScopeClosed, releaseStream, cached } =
+      yield* makeStreamingRefresh;
+
+    yield* withBrowserRefresh(navigation, browserRenderer, routeLoader, (refresh) =>
+      Effect.gen(function* () {
+        yield* refresh('hmr-refresh');
+        const render = yield* Effect.promise(() => published.promise);
+        browserRenderer.commit(render);
+        yield* Effect.yieldNow;
+
+        // Scheduling a successor does not remove the refreshed page from the screen.
+        published = Promise.withResolvers<BrowserRender>();
+        navigation.dispatchEvent(routedNavigation());
+        browserRenderer.navigate(makeRouteTree('replacement'));
+        const replacement = yield* Effect.promise(() => published.promise);
+        yield* Effect.yieldNow;
+        expect(releaseStream).not.toHaveBeenCalled();
+
+        browserRenderer.commit(replacement);
+        yield* Deferred.await(streamReleased);
+        yield* Deferred.await(responseScopeClosed);
+        expect(releaseStream).toHaveBeenCalledOnce();
+        expect(cached).not.toHaveBeenCalled();
+      }),
+    );
+  }),
+);
+
+it.effect('discards an uncommitted refresh before releasing its response', () =>
+  Effect.gen(function* () {
+    const navigation = new TestNavigation();
+    const browserRenderer = yield* BrowserRenderer.make;
+    let published = Promise.withResolvers<BrowserRender>();
+    const initialTree = makeRouteTree('initial');
+    browserRenderer.initialize(initialTree, (render) => published.resolve(render));
+    const { routeLoader, streamReleased, responseScopeClosed, releaseStream, cached } =
+      yield* makeStreamingRefresh;
+
+    yield* withBrowserRefresh(navigation, browserRenderer, routeLoader, (refresh, interrupt) =>
+      Effect.gen(function* () {
+        yield* refresh('hmr-refresh');
+        const pending = yield* Effect.promise(() => published.promise);
+        expect(pending._tag).toBe('Refresh');
+
+        published = Promise.withResolvers<BrowserRender>();
+        yield* interrupt;
+        const discard = yield* Effect.promise(() => published.promise);
+        expect(discard._tag).toBe('Discard');
+        expect(discard.routeTree).toBe(initialTree);
+        expect(releaseStream).not.toHaveBeenCalled();
+        expect(Deferred.isDoneUnsafe(responseScopeClosed)).toBe(false);
+
+        // React must acknowledge the discard before the old response can be cancelled.
+        browserRenderer.commit(discard);
+        yield* Deferred.await(streamReleased);
+        yield* Deferred.await(responseScopeClosed);
+        expect(releaseStream).toHaveBeenCalledOnce();
+        expect(cached).not.toHaveBeenCalled();
+      }),
+    );
+  }),
+);
+
+it.effect('keeps response ownership when navigation interrupts refresh publication', () =>
+  Effect.gen(function* () {
+    const navigation = new TestNavigation();
+    const browserRenderer = yield* BrowserRenderer.make;
+    const discardPublished = Promise.withResolvers<BrowserRender>();
+    browserRenderer.initialize(makeRouteTree('initial'), (render) => {
+      if (render._tag === 'Refresh') {
+        // Navigation arrives during publication, before the refresh has returned its render handle.
+        navigation.dispatchEvent(routedNavigation());
+      } else {
+        discardPublished.resolve(render);
+      }
+    });
+    const allowLoad = yield* Deferred.make<void>();
+    const { routeLoader, responseScopeClosed, releaseStream } = yield* makeStreamingRefresh;
+    const delayedLoader = RouteLoader.of({
+      ...routeLoader,
+      load: (request) => Deferred.await(allowLoad).pipe(Effect.andThen(routeLoader.load(request))),
+    });
+
+    yield* withBrowserRefresh(navigation, browserRenderer, delayedLoader, (refresh) =>
+      Effect.gen(function* () {
+        yield* refresh('hmr-refresh');
+        yield* Effect.yieldNow;
+        yield* Deferred.succeed(allowLoad, undefined);
+        const discard = yield* Effect.promise(() => discardPublished.promise);
+        expect(discard._tag).toBe('Discard');
+        expect(releaseStream).not.toHaveBeenCalled();
+        expect(Deferred.isDoneUnsafe(responseScopeClosed)).toBe(false);
+
+        browserRenderer.commit(discard);
+        yield* Deferred.await(responseScopeClosed);
+        expect(releaseStream).toHaveBeenCalledOnce();
+      }),
+    );
+  }),
+);
+
+it.effect('releases a visible refresh when the browser runtime shuts down', () =>
+  Effect.gen(function* () {
+    const navigation = new TestNavigation();
+    const browserRenderer = yield* BrowserRenderer.make;
+    const published = Promise.withResolvers<BrowserRender>();
+    browserRenderer.initialize(makeRouteTree('initial'), published.resolve);
+    const { routeLoader, responseScopeClosed, releaseStream } = yield* makeStreamingRefresh;
+
+    yield* withBrowserRefresh(navigation, browserRenderer, routeLoader, (refresh) =>
+      Effect.gen(function* () {
+        yield* refresh('hmr-refresh');
+        const render = yield* Effect.promise(() => published.promise);
+        browserRenderer.commit(render);
+        yield* Effect.yieldNow;
+        expect(releaseStream).not.toHaveBeenCalled();
+      }),
+    );
+
+    yield* Deferred.await(responseScopeClosed);
+    expect(releaseStream).toHaveBeenCalledOnce();
+  }),
+);
+
 it.effect('interrupts a current-route refresh when another refresh source supersedes it', () =>
   Effect.gen(function* () {
     const navigation = new TestNavigation();
     const loadStarted = yield* Deferred.make<void>();
     const loadInterrupted = yield* Deferred.make<void>();
-    const rootRefresh = vi.fn(() => Promise.resolve());
+    const rootRefresh = vi.fn(committedRefresh);
     const routeLoader = RouteLoader.of({
       invalidate: vi.fn(),
       load: () =>
@@ -371,7 +600,7 @@ it.effect('replaces an older refresh when a newer development update arrives', (
       },
       refresh: (nextRouteTree) => {
         secondRendered.resolve(nextRouteTree);
-        return Promise.resolve();
+        return committedRefresh();
       },
     });
 


### PR DESCRIPTION
Starting a navigation could cancel a committed current-route refresh while its page was still visible and waiting for more Flight data. Keep published refresh responses alive until the stream finishes or React confirms that the render has retired, and discard pending renders before releasing their responses.

Use Effect's `FiberHandle` for the pending refresh and `forkIn` for continued streaming. Add regressions for visible-stream retention, replacement, precommit discard, interruption during publication, and browser shutdown. Update the owning lifecycle documentation.

Server Function response trees also release their Flight responses when a replacement commits. A regression using the real renderer reproduced the missing release; retirement now releases the response without caching an unfinished tree.

Validation: `bun run check`, `bun run build`, and `bun run test` passed from the repository root: 339 unit tests and 99 browser tests passed, with 13 existing skips.
