### PR TITLE
fix(example): preserve authoring constraints and isolate browser journeys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,7 @@ jobs:
           path: |
             fixtures/framework-e2e/playwright-report
             fixtures/framework-e2e/test-results
+            examples/event-platform/playwright-report
+            examples/event-platform/test-results
           if-no-files-found: ignore
           retention-days: 7

--- a/examples/event-platform/README.md
+++ b/examples/event-platform/README.md
@@ -14,7 +14,8 @@ Open `http://localhost:18193`. `bun run build` then `bun run start` runs the pro
 Application state uses a durable Bun SQLite database at `.data/event-platform.sqlite`. Migrations
 seed two fictional organizations and public events. Remove the local database when you
 intentionally want to replay the seed data, or set `EVENT_PLATFORM_DATABASE_FILENAME` to choose
-another SQLite database.
+another SQLite database. Ticket sale windows use UTC in storage; a migration repairs older
+local-time values using the owning event’s timezone.
 
 ## Test it
 
@@ -24,9 +25,10 @@ bun run test:e2e  # Playwright: product journeys in production and development
 ```
 
 After a build, `test:e2e` runs every product journey twice: once against `ersc start` on port 18204
-and once against `ersc dev` on port 18205. Each server gets its own in-memory SQLite database and
-seed data, so the projects cannot race through shared state. Playwright owns both E2E ports, so the
-normal development server can keep running on port 18193.
+and once against `ersc dev` on port 18205. Each journey starts a fresh server with its own in-memory
+SQLite database and seed data. Retries and repeated runs therefore do not inherit earlier purchases,
+refunds, or edits. The suite
+uses one worker and owns both E2E ports; the normal development server can keep running on port 18193.
 
 ## What it exercises
 
@@ -61,7 +63,8 @@ and its derived middleware views.
   inventory and visibility controls.
 - Programme management at `/organizer/events/:eventId/programme`, including reusable rooms and
   speaker profiles, timezone-aware session scheduling, room and speaker conflict prevention,
-  capacity constraints, and per-session draft, published, and cancelled states.
+  capacity constraints, and per-session draft, published, and cancelled states. Event edits must
+  keep existing sessions within the event’s dates and capacity.
 - Database-backed public programmes at
   `/events/:organizationSlug/:eventSlug/programme`; only published sessions are visible.
 - Public registration at `/events/:organizationSlug/:eventSlug/register`, with ticket inventory,

--- a/examples/event-platform/e2e/check-in.spec.ts
+++ b/examples/event-platform/e2e/check-in.spec.ts
@@ -1,7 +1,6 @@
 // oxlint-disable effecttsgo/async-function -- Playwright owns this Promise-based browser-test boundary.
-import { expect, test } from '@playwright/test';
-
 import { observeBrowserErrors } from './support/browser-errors';
+import { expect, test } from './support/test';
 
 test('checks in a credential and reverses the operation', async ({ page }) => {
   const browserErrors = observeBrowserErrors(page);

--- a/examples/event-platform/e2e/discovery.spec.ts
+++ b/examples/event-platform/e2e/discovery.spec.ts
@@ -1,7 +1,6 @@
 // oxlint-disable effecttsgo/async-function -- Playwright owns this Promise-based browser-test boundary.
-import { expect, test } from '@playwright/test';
-
 import { observeBrowserErrors } from './support/browser-errors';
+import { expect, test } from './support/test';
 
 test('discovers an event and opens its published programme', async ({ page }) => {
   const browserErrors = observeBrowserErrors(page);

--- a/examples/event-platform/e2e/organizer.spec.ts
+++ b/examples/event-platform/e2e/organizer.spec.ts
@@ -1,7 +1,6 @@
 // oxlint-disable effecttsgo/async-function -- Playwright owns this Promise-based browser-test boundary.
-import { expect, test } from '@playwright/test';
-
 import { observeBrowserErrors } from './support/browser-errors';
+import { expect, test } from './support/test';
 
 test('authors, publishes, discovers, and registers for an event', async ({ page }, testInfo) => {
   const browserErrors = observeBrowserErrors(page);
@@ -48,6 +47,8 @@ test('authors, publishes, discovers, and registers for an event', async ({ page 
   const authoredTicket = page
     .locator('form')
     .filter({ has: page.getByRole('heading', { name: 'Standard admission' }) });
+  await expect(authoredTicket.getByLabel('Sales start')).toHaveValue('2026-01-01T00:00');
+  await expect(authoredTicket.getByLabel('Sales end')).toHaveValue('2099-02-11T08:00');
   await authoredTicket.getByRole('button', { name: 'Hide from sale' }).click();
   await expect(authoredTicket.getByText('Ticket is hidden.')).toBeVisible();
   await authoredTicket.getByLabel('Quantity').fill('101');
@@ -129,6 +130,20 @@ test('authors, publishes, discovers, and registers for an event', async ({ page 
   await expect(page.getByRole('heading', { name: 'You’re registered' })).toBeVisible();
 
   expect(browserErrors).toEqual([]);
+});
+
+test('rejects event dates that would leave a session outside the event', async ({ page }) => {
+  await page.goto('/organizer/events/event-rsc-workshop-lab-2026/edit');
+  await page.getByLabel('Starts', { exact: true }).fill('2026-12-05T11:00');
+  await page.getByRole('button', { name: 'Save event', exact: true }).click();
+  await expect(
+    page.getByText(
+      'Existing sessions must fit within the event dates and capacity. Update the programme first.',
+    ),
+  ).toBeVisible();
+  await expect(page.getByLabel('Starts', { exact: true })).toHaveValue('2026-12-05T11:00');
+  await page.reload();
+  await expect(page.getByLabel('Starts', { exact: true })).toHaveValue('2026-12-05T09:30');
 });
 
 test('reviews event sales and attendance as an organization owner', async ({ page }) => {

--- a/examples/event-platform/e2e/registration.spec.ts
+++ b/examples/event-platform/e2e/registration.spec.ts
@@ -1,7 +1,6 @@
 // oxlint-disable effecttsgo/async-function -- Playwright owns this Promise-based browser-test boundary.
-import { expect, test } from '@playwright/test';
-
 import { observeBrowserErrors } from './support/browser-errors';
+import { expect, test } from './support/test';
 
 test('registers an attendee and manages the issued ticket', async ({ page }, testInfo) => {
   const browserErrors = observeBrowserErrors(page);

--- a/examples/event-platform/e2e/support/test.ts
+++ b/examples/event-platform/e2e/support/test.ts
@@ -1,0 +1,96 @@
+// oxlint-disable effecttsgo/async-function, effecttsgo/node-builtin-import, effecttsgo/global-timers -- Playwright owns the test server and its Promise-based lifecycle.
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test as base } from '@playwright/test';
+
+const applicationDirectory = fileURLToPath(new URL('../../', import.meta.url));
+
+export const test = base.extend({
+  baseURL: [
+    async ({ playwright }, use, testInfo) => {
+      const port = testInfo.project.name === 'dev' ? '18205' : '18204';
+      const origin = `http://localhost:${port}`;
+      const probe = await playwright.request.newContext({ baseURL: origin });
+      const occupied = await probe.get('/', { timeout: 1_000 }).then(
+        () => true,
+        () => false,
+      );
+      if (occupied) {
+        await probe.dispose();
+        throw new Error(`The test requires an unused application port: ${port}`);
+      }
+      // A fresh process owns a fresh in-memory database for every journey, including retries.
+      const server = spawn('bun', ['run', testInfo.project.name], {
+        cwd: applicationDirectory,
+        detached: true,
+        env: { ...process.env, EVENT_PLATFORM_DATABASE_FILENAME: ':memory:', PORT: port },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let output = '';
+      let startupError: Error | undefined;
+      server.stdout.on('data', (chunk) => {
+        output += String(chunk);
+      });
+      server.stderr.on('data', (chunk) => {
+        output += String(chunk);
+      });
+      server.on('error', (error) => {
+        startupError = error;
+      });
+      const closed = once(server, 'close').catch((error: Error) => {
+        startupError = error;
+      });
+      const stop = (signal: NodeJS.Signals) => {
+        if (server.pid !== undefined) {
+          try {
+            process.kill(-server.pid, signal);
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+              throw error;
+            }
+          }
+        }
+      };
+
+      try {
+        await expect
+          .poll(
+            async () => {
+              if (startupError !== undefined) {
+                throw startupError;
+              }
+              if (server.exitCode !== null) {
+                throw new Error(`Application exited before readiness: ${output}`);
+              }
+              try {
+                const response = await probe.get('/', { timeout: 1_000 });
+                return response.status();
+              } catch {
+                return 0;
+              }
+            },
+            { timeout: 30_000, message: 'The isolated application must be ready' },
+          )
+          .toBe(200);
+        await use(origin);
+      } finally {
+        stop('SIGINT');
+        const forceStop = setTimeout(() => stop('SIGKILL'), 5_000);
+        try {
+          await closed;
+        } finally {
+          clearTimeout(forceStop);
+          await probe.dispose();
+        }
+        if (testInfo.status !== testInfo.expectedStatus) {
+          await testInfo.attach('application.log', { body: output, contentType: 'text/plain' });
+        }
+      }
+    },
+    { scope: 'test', timeout: 45_000 },
+  ],
+});
+
+export { expect } from '@playwright/test';

--- a/examples/event-platform/playwright.config.ts
+++ b/examples/event-platform/playwright.config.ts
@@ -1,9 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const startOrigin = 'http://localhost:18204';
-const developmentOrigin = 'http://localhost:18205';
-const isolatedDatabase = { EVENT_PLATFORM_DATABASE_FILENAME: ':memory:' };
-
 export default defineConfig({
   expect: {
     timeout: 15_000,
@@ -22,40 +18,12 @@ export default defineConfig({
       name: 'start',
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: startOrigin,
       },
     },
     {
       name: 'dev',
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: developmentOrigin,
-      },
-    },
-  ],
-  webServer: [
-    {
-      command: 'ersc start',
-      env: { ...isolatedDatabase, PORT: '18204' },
-      name: 'start',
-      url: startOrigin,
-      reuseExistingServer: false,
-      timeout: 30_000,
-      gracefulShutdown: {
-        signal: 'SIGINT',
-        timeout: 5_000,
-      },
-    },
-    {
-      command: 'ersc dev',
-      env: { ...isolatedDatabase, PORT: '18205' },
-      name: 'dev',
-      url: developmentOrigin,
-      reuseExistingServer: false,
-      timeout: 30_000,
-      gracefulShutdown: {
-        signal: 'SIGINT',
-        timeout: 5_000,
       },
     },
   ],

--- a/examples/event-platform/src/modules/event-authoring/model.ts
+++ b/examples/event-platform/src/modules/event-authoring/model.ts
@@ -101,6 +101,11 @@ export class EventScheduleInvalid extends Schema.TaggedError<EventScheduleInvali
   { field: Schema.String },
 ) {}
 
+export class EventProgrammeInvalid extends Schema.TaggedError<EventProgrammeInvalid>()(
+  '@effective-rsc/example-event-platform/event-authoring/EventProgrammeInvalid',
+  { eventId: Schema.String },
+) {}
+
 export class EventAuthoringConcurrentUpdate extends Schema.TaggedError<EventAuthoringConcurrentUpdate>()(
   '@effective-rsc/example-event-platform/event-authoring/EventAuthoringConcurrentUpdate',
   { eventId: Schema.String },

--- a/examples/event-platform/src/modules/event-authoring/repository.ts
+++ b/examples/event-platform/src/modules/event-authoring/repository.ts
@@ -5,6 +5,7 @@ import {
   AuthoringOrganization,
   type CreateEventInput,
   EditableEvent,
+  EventProgrammeInvalid,
   type EventDetailsInput,
   type EventEditor,
   ManagedTicketType,
@@ -270,7 +271,15 @@ export class EventAuthoringRepository extends Context.Service<EventAuthoringRepo
                   AND role IN ('owner', 'admin', 'event_manager')
               )
             RETURNING id AS eventId
-          `;
+          `.pipe(
+            Effect.mapError((error) =>
+              error.reason._tag === 'ConstraintError' &&
+              error.reason.cause instanceof Error &&
+              error.reason.cause.message === 'event would invalidate programme'
+                ? new EventProgrammeInvalid({ eventId })
+                : error,
+            ),
+          );
 
           return rows.length === 1;
         }),

--- a/examples/event-platform/src/modules/event-authoring/server-functions.ts
+++ b/examples/event-platform/src/modules/event-authoring/server-functions.ts
@@ -82,6 +82,12 @@ const failureState = (error: EventAuthoringError): AuthoringMutationState => {
         message: `Check the ${error.field} value and event timezone. End time must follow start time.`,
         status: 'error',
       };
+    case '@effective-rsc/example-event-platform/event-authoring/EventProgrammeInvalid':
+      return {
+        message:
+          'Existing sessions must fit within the event dates and capacity. Update the programme first.',
+        status: 'error',
+      };
     case '@effective-rsc/example-event-platform/event-authoring/EventAuthoringConcurrentUpdate':
       return {
         message: 'This event changed in another request. Refresh and apply your edits again.',

--- a/examples/event-platform/src/modules/event-authoring/service.ts
+++ b/examples/event-platform/src/modules/event-authoring/service.ts
@@ -7,6 +7,7 @@ import {
   EventAuthoringUnavailable,
   type EventDetailsInput,
   EventScheduleInvalid,
+  EventProgrammeInvalid,
   EventSlugConflict,
   TicketInventoryInvalid,
   type TicketTypeInput,
@@ -22,6 +23,7 @@ export type EventAuthoringError =
   | EventAuthoringAccessDenied
   | EventAuthoringConcurrentUpdate
   | EventAuthoringUnavailable
+  | EventProgrammeInvalid
   | EventScheduleInvalid
   | EventSlugConflict
   | TicketInventoryInvalid
@@ -162,7 +164,11 @@ export class EventAuthoringService extends Context.Service<EventAuthoringService
             input.salesEndsAt,
             editor.event.timezone,
           );
-          const normalized = { ...input, ...range };
+          const normalized = {
+            ...input,
+            salesStartsAt: range.startsAt,
+            salesEndsAt: range.endsAt,
+          };
           if (input.ticketTypeId === undefined) {
             const ticketTypeId = yield* repository
               .createTicketType(userId, normalized)
@@ -246,7 +252,14 @@ export class EventAuthoringService extends Context.Service<EventAuthoringService
           const updatedAt = DateTime.formatIso(currentTime);
           const updated = yield* repository
             .updateEvent(userId, input.eventId, details, input.expectedUpdatedAt, updatedAt)
-            .pipe(unavailable('update event details'));
+            .pipe(
+              Effect.mapError((error) =>
+                error._tag ===
+                '@effective-rsc/example-event-platform/event-authoring/EventProgrammeInvalid'
+                  ? error
+                  : new EventAuthoringUnavailable({ operation: 'update event details' }),
+              ),
+            );
           if (!updated) {
             return yield* new EventAuthoringConcurrentUpdate({ eventId: input.eventId });
           }

--- a/examples/event-platform/src/modules/programme/repository.ts
+++ b/examples/event-platform/src/modules/programme/repository.ts
@@ -283,6 +283,22 @@ export class ProgrammeRepository extends Context.Service<ProgrammeRepository>()(
                     RETURNING id AS sessionId
                   `;
               } else {
+                // Remove the old assignment before checking the new schedule. The transaction
+                // restores it if either the schedule or the replacement speaker conflicts.
+                yield* sql`
+                  DELETE FROM programme_session_speakers
+                  WHERE session_id IN (
+                    SELECT programme_sessions.id
+                    FROM programme_sessions
+                    INNER JOIN events ON events.id = programme_sessions.event_id
+                    INNER JOIN organization_memberships
+                      ON organization_memberships.organization_id = events.organization_id
+                    WHERE programme_sessions.id = ${input.sessionId}
+                      AND events.id = ${input.eventId}
+                      AND organization_memberships.user_id = ${userId}
+                      AND organization_memberships.role IN ('owner', 'admin', 'event_manager')
+                  )
+                `;
                 rows = yield* sql<{ readonly sessionId: string }>`
                     UPDATE programme_sessions
                     SET
@@ -312,10 +328,6 @@ export class ProgrammeRepository extends Context.Service<ProgrammeRepository>()(
                 return null;
               }
 
-              yield* sql`
-                DELETE FROM programme_session_speakers
-                WHERE session_id = ${sessionId}
-              `;
               const speakerRows = yield* sql<{ readonly speakerId: string }>`
                 INSERT INTO programme_session_speakers (session_id, speaker_id)
                 SELECT ${sessionId}, id

--- a/examples/event-platform/src/persistence/Migrations.ts
+++ b/examples/event-platform/src/persistence/Migrations.ts
@@ -12,6 +12,8 @@ import Migration010 from '@/persistence/Migrations/010_DiscountCodes';
 import Migration011 from '@/persistence/Migrations/011_Waitlists';
 import Migration012 from '@/persistence/Migrations/012_RegistrationQuestions';
 import Migration013 from '@/persistence/Migrations/013_ReleaseHardening';
+import Migration014 from '@/persistence/Migrations/014_ProgrammeEventConstraints';
+import Migration015 from '@/persistence/Migrations/015_TicketSaleInstants';
 
 const loader = SqliteMigrator.fromRecord({
   '2_EventPlatform': Migration002,
@@ -26,6 +28,8 @@ const loader = SqliteMigrator.fromRecord({
   '11_Waitlists': Migration011,
   '12_RegistrationQuestions': Migration012,
   '13_ReleaseHardening': Migration013,
+  '14_ProgrammeEventConstraints': Migration014,
+  '15_TicketSaleInstants': Migration015,
 });
 
 export const runMigrations = SqliteMigrator.run({ loader });

--- a/examples/event-platform/src/persistence/Migrations/014_ProgrammeEventConstraints.ts
+++ b/examples/event-platform/src/persistence/Migrations/014_ProgrammeEventConstraints.ts
@@ -1,0 +1,57 @@
+import { Effect } from 'effect';
+import { SqlClient } from 'effect/unstable/sql/SqlClient';
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient;
+
+  yield* sql`
+    CREATE TRIGGER events_programme_before_update
+    BEFORE UPDATE OF capacity, starts_at, ends_at ON events
+    WHEN EXISTS (
+      SELECT 1 FROM programme_sessions
+      WHERE event_id = NEW.id
+        AND (
+          capacity > NEW.capacity
+          OR julianday(starts_at) < julianday(NEW.starts_at)
+          OR julianday(ends_at) > julianday(NEW.ends_at)
+        )
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'event would invalidate programme');
+    END
+  `;
+
+  // Check both edit directions so a session saved after an event edit cannot use stale bounds.
+  yield* sql`
+    CREATE TRIGGER programme_event_before_insert
+    BEFORE INSERT ON programme_sessions
+    WHEN EXISTS (
+      SELECT 1 FROM events
+      WHERE id = NEW.event_id
+        AND (
+          NEW.capacity > capacity
+          OR julianday(NEW.starts_at) < julianday(starts_at)
+          OR julianday(NEW.ends_at) > julianday(ends_at)
+        )
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'session exceeds event dates or capacity');
+    END
+  `;
+  yield* sql`
+    CREATE TRIGGER programme_event_before_update
+    BEFORE UPDATE OF event_id, capacity, starts_at, ends_at ON programme_sessions
+    WHEN EXISTS (
+      SELECT 1 FROM events
+      WHERE id = NEW.event_id
+        AND (
+          NEW.capacity > capacity
+          OR julianday(NEW.starts_at) < julianday(starts_at)
+          OR julianday(NEW.ends_at) > julianday(ends_at)
+        )
+    )
+    BEGIN
+      SELECT RAISE(ABORT, 'session exceeds event dates or capacity');
+    END
+  `;
+});

--- a/examples/event-platform/src/persistence/Migrations/015_TicketSaleInstants.ts
+++ b/examples/event-platform/src/persistence/Migrations/015_TicketSaleInstants.ts
@@ -1,0 +1,47 @@
+import { DateTime, Effect, Schema } from 'effect';
+import { SqlClient } from 'effect/unstable/sql/SqlClient';
+
+class TicketSaleTimeInvalid extends Schema.TaggedError<TicketSaleTimeInvalid>()(
+  '@effective-rsc/example-event-platform/persistence/TicketSaleTimeInvalid',
+  { value: Schema.String, timezone: Schema.String },
+) {}
+
+// Earlier ticket authoring stored datetime-local form values without converting them to UTC.
+const saleInstant = Effect.fnUntraced(function* (value: string, timezone: string) {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value)) {
+    return value;
+  }
+  const instant = yield* Effect.fromOption(
+    DateTime.makeZoned(value, {
+      timeZone: timezone,
+      adjustForTimeZone: true,
+      disambiguation: 'reject',
+    }),
+    () => new TicketSaleTimeInvalid({ value, timezone }),
+  );
+  return DateTime.formatIso(instant);
+});
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient;
+  const tickets = yield* sql<{
+    readonly id: string;
+    readonly timezone: string;
+    readonly salesStartsAt: string;
+    readonly salesEndsAt: string;
+  }>`
+    SELECT ticket_types.id, events.timezone,
+      sales_starts_at AS salesStartsAt, sales_ends_at AS salesEndsAt
+    FROM ticket_types
+    INNER JOIN events ON events.id = ticket_types.event_id
+    WHERE length(sales_starts_at) = 16 OR length(sales_ends_at) = 16
+  `;
+  for (const ticket of tickets) {
+    const startsAt = yield* saleInstant(ticket.salesStartsAt, ticket.timezone);
+    const endsAt = yield* saleInstant(ticket.salesEndsAt, ticket.timezone);
+    yield* sql`
+      UPDATE ticket_types SET sales_starts_at = ${startsAt}, sales_ends_at = ${endsAt}
+      WHERE id = ${ticket.id}
+    `;
+  }
+});

--- a/examples/event-platform/tests/event-authoring/integration.test.ts
+++ b/examples/event-platform/tests/event-authoring/integration.test.ts
@@ -1,0 +1,189 @@
+import { SqliteClient } from '@effect/sql-sqlite-bun';
+import { describe, expect, it } from '@effect/vitest';
+import { Effect, Layer } from 'effect';
+import { SqlClient } from 'effect/unstable/sql/SqlClient';
+
+import { EventAuthoringRepository } from '@/modules/event-authoring/repository';
+import { EventAuthoringService } from '@/modules/event-authoring/service';
+import { RegistrationRepository } from '@/modules/registration/repository';
+import { runMigrations } from '@/persistence/Migrations';
+import repairTicketSaleInstants from '@/persistence/Migrations/015_TicketSaleInstants';
+
+const PersistenceLayer = Layer.effectDiscard(runMigrations).pipe(
+  Layer.provideMerge(SqliteClient.layer({ filename: ':memory:' })),
+);
+const ServiceLayer = Layer.mergeAll(
+  EventAuthoringService.layer.pipe(Layer.provide(EventAuthoringRepository.layer)),
+  RegistrationRepository.layer,
+).pipe(Layer.provideMerge(PersistenceLayer));
+
+const workshopId = 'event-rsc-workshop-lab-2026';
+
+describe('Event authoring with SQLite', () => {
+  it.effect('opens and closes ticket sales at the venue-local times on creation and edit', () =>
+    Effect.gen(function* () {
+      const authoring = yield* EventAuthoringService;
+      const registration = yield* RegistrationRepository;
+      const sql = yield* SqlClient;
+      yield* sql`UPDATE events SET status = 'published' WHERE id = ${workshopId}`;
+      const ticket = {
+        eventId: workshopId,
+        name: 'Morning admission',
+        description: 'Admission to the workshop.',
+        currency: 'INR',
+        priceMinor: 500,
+        quantityTotal: 20,
+        salesStartsAt: '2026-12-01T09:00',
+        salesEndsAt: '2026-12-01T10:00',
+      };
+
+      const created = yield* authoring.saveTicketType('user-nikhil', ticket);
+      const editor = yield* authoring.editor('user-nikhil', workshopId);
+      expect(editor.tickets[0]).toMatchObject({
+        ticketTypeId: created.ticketTypeId,
+        salesStartsAt: '2026-12-01T03:30:00.000Z',
+        salesEndsAt: '2026-12-01T04:30:00.000Z',
+      });
+      // The venue is in Asia/Kolkata: 09:00 there is 03:30 UTC.
+      for (const [instant, count] of [
+        ['2026-12-01T03:29:59Z', 0],
+        ['2026-12-01T03:30:00Z', 1],
+        ['2026-12-01T04:30:00Z', 1],
+        ['2026-12-01T04:30:01Z', 0],
+      ] as const) {
+        const available = yield* registration.listAvailable(workshopId, instant);
+        expect(available, instant).toHaveLength(count);
+      }
+
+      yield* authoring.saveTicketType('user-nikhil', {
+        ...ticket,
+        ticketTypeId: created.ticketTypeId,
+        salesStartsAt: '2026-12-01T11:00',
+        salesEndsAt: '2026-12-01T12:00',
+      });
+      const edited = yield* authoring.editor('user-nikhil', workshopId);
+      expect(edited.tickets[0]).toMatchObject({
+        salesStartsAt: '2026-12-01T05:30:00.000Z',
+        salesEndsAt: '2026-12-01T06:30:00.000Z',
+      });
+      for (const [instant, count] of [
+        ['2026-12-01T03:30:00Z', 0],
+        ['2026-12-01T05:29:59Z', 0],
+        ['2026-12-01T05:30:00Z', 1],
+        ['2026-12-01T06:30:00Z', 1],
+        ['2026-12-01T06:30:01Z', 0],
+      ] as const) {
+        const available = yield* registration.listAvailable(workshopId, instant);
+        expect(available, instant).toHaveLength(count);
+      }
+    }).pipe(Effect.provide(ServiceLayer)),
+  );
+
+  it.effect('repairs legacy local sale times without converting UTC values a second time', () =>
+    Effect.gen(function* () {
+      const authoring = yield* EventAuthoringService;
+      const sql = yield* SqlClient;
+      const { ticketTypeId } = yield* authoring.saveTicketType('user-nikhil', {
+        eventId: workshopId,
+        name: 'Legacy admission',
+        description: 'A ticket saved before the normalization fix.',
+        currency: 'INR',
+        priceMinor: 500,
+        quantityTotal: 20,
+        salesStartsAt: '2026-12-01T09:00',
+        salesEndsAt: '2026-12-01T12:00',
+      });
+      yield* sql`
+        UPDATE ticket_types
+        SET sales_starts_at = '2026-12-01T09:00', sales_ends_at = '2026-12-01T12:00'
+        WHERE id = ${ticketTypeId}
+      `;
+      yield* repairTicketSaleInstants;
+      const repaired = yield* authoring.editor('user-nikhil', workshopId);
+      expect(repaired.tickets[0]).toMatchObject({
+        salesStartsAt: '2026-12-01T03:30:00.000Z',
+        salesEndsAt: '2026-12-01T06:30:00.000Z',
+      });
+      yield* repairTicketSaleInstants;
+      const repeated = yield* authoring.editor('user-nikhil', workshopId);
+      expect(repeated.tickets).toEqual(repaired.tickets);
+    }).pipe(Effect.provide(ServiceLayer)),
+  );
+
+  for (const [description, changes] of [
+    ['capacity below an existing session', { capacity: 79 }],
+    ['start after an existing session begins', { startsAt: '2026-12-05T11:00' }],
+    ['end before an existing session finishes', { endsAt: '2026-12-05T13:00' }],
+  ] as const) {
+    it.effect(`rejects event ${description} without changing the event`, () =>
+      Effect.gen(function* () {
+        const authoring = yield* EventAuthoringService;
+        const { event } = yield* authoring.editor('user-nikhil', workshopId);
+        const error = yield* authoring
+          .updateEvent('user-nikhil', {
+            ...event,
+            expectedUpdatedAt: event.updatedAt,
+            startsAt: '2026-12-05T09:30',
+            endsAt: '2026-12-05T17:30',
+            ...changes,
+          })
+          .pipe(Effect.flip);
+
+        expect(error._tag).toBe(
+          '@effective-rsc/example-event-platform/event-authoring/EventProgrammeInvalid',
+        );
+        const after = yield* authoring.editor('user-nikhil', workshopId);
+        expect(after.event).toEqual(event);
+      }).pipe(Effect.provide(ServiceLayer)),
+    );
+  }
+
+  for (const [description, startsAt, endsAt, capacity] of [
+    ['capacity', '2026-12-05T09:00:00Z', '2026-12-05T10:00:00Z', 81],
+    ['start', '2026-12-05T03:00:00Z', '2026-12-05T04:00:00Z', 28],
+    ['end', '2026-12-05T12:00:00Z', '2026-12-05T13:00:00Z', 28],
+  ] as const) {
+    it.effect(`checks event ${description} bounds when a session is inserted or updated`, () =>
+      Effect.gen(function* () {
+        const sql = yield* SqlClient;
+        // These writes bypass the service's earlier checks, as a stale request could.
+        const inserted = yield* sql`
+          INSERT INTO programme_sessions (
+            id, event_id, room_id, title, summary, starts_at, ends_at,
+            capacity, status, created_at, updated_at
+          ) VALUES (
+            'invalid-session', ${workshopId}, 'room-workshop-clinic', 'Invalid session', '',
+            ${startsAt}, ${endsAt}, ${capacity}, 'draft', '2026-09-08', '2026-09-08'
+          )
+        `.pipe(Effect.flip);
+        expect(inserted.reason.cause).toMatchObject({
+          message: 'session exceeds event dates or capacity',
+        });
+        const updated = yield* sql`
+          UPDATE programme_sessions
+          SET starts_at = ${startsAt}, ends_at = ${endsAt}, capacity = ${capacity}
+          WHERE id = 'session-workshop-debugging'
+        `.pipe(Effect.flip);
+        expect(updated.reason.cause).toMatchObject({
+          message: 'session exceeds event dates or capacity',
+        });
+      }).pipe(Effect.provide(ServiceLayer)),
+    );
+  }
+
+  it.effect('allows event edits that still contain the existing programme', () =>
+    Effect.gen(function* () {
+      const authoring = yield* EventAuthoringService;
+      const { event } = yield* authoring.editor('user-nikhil', workshopId);
+      yield* authoring.updateEvent('user-nikhil', {
+        ...event,
+        expectedUpdatedAt: event.updatedAt,
+        startsAt: '2026-12-05T09:30',
+        endsAt: '2026-12-05T17:30',
+        name: 'Renamed workshop',
+      });
+      const after = yield* authoring.editor('user-nikhil', workshopId);
+      expect(after.event.name).toBe('Renamed workshop');
+    }).pipe(Effect.provide(ServiceLayer)),
+  );
+});

--- a/examples/event-platform/tests/programme/repository.test.ts
+++ b/examples/event-platform/tests/programme/repository.test.ts
@@ -124,6 +124,103 @@ describe('ProgrammeRepository', () => {
     }).pipe(Effect.provide(RepositoryLayer)),
   );
 
+  it.effect('moves a session and changes its speaker using the final assignment', () =>
+    Effect.gen(function* () {
+      const repository = yield* ProgrammeRepository;
+      const eventId = 'event-rsc-workshop-lab-2026';
+      // Priya has a second booking at 09:00 in the clinic.
+      yield* repository.saveSession(
+        'user-nikhil',
+        {
+          eventId,
+          roomId: 'room-workshop-clinic',
+          speakerId: 'speaker-workshop-priya',
+          startsAt: '2026-12-05T09:00:00.000Z',
+          endsAt: '2026-12-05T10:00:00.000Z',
+          capacity: 28,
+          title: 'Priya’s next session',
+          summary: 'A separate booking.',
+        },
+        '2026-09-08T10:01:00.000Z',
+      );
+      // Move her studio session to the same time, with Daniel replacing her.
+      const sessionId = yield* repository.saveSession(
+        'user-nikhil',
+        {
+          sessionId: 'session-workshop-flight',
+          eventId,
+          roomId: 'room-workshop-studio',
+          speakerId: 'speaker-workshop-daniel',
+          startsAt: '2026-12-05T09:00:00.000Z',
+          endsAt: '2026-12-05T10:00:00.000Z',
+          capacity: 80,
+          title: 'Flight workshop',
+          summary: 'Rescheduled with Daniel.',
+        },
+        '2026-09-08T10:02:00.000Z',
+      );
+      const editor = yield* repository.loadEditor('user-nikhil', eventId);
+      expect(editor?.sessions.find((session) => session.sessionId === sessionId)).toMatchObject({
+        startsAt: '2026-12-05T09:00:00.000Z',
+        speakerId: 'speaker-workshop-daniel',
+      });
+    }).pipe(Effect.provide(RepositoryLayer)),
+  );
+
+  it.effect('rolls back both the schedule and speaker when the final assignment conflicts', () =>
+    Effect.gen(function* () {
+      const repository = yield* ProgrammeRepository;
+      const eventId = 'event-rsc-workshop-lab-2026';
+      const before = yield* repository.loadEditor('user-nikhil', eventId);
+      const failed = yield* repository
+        .saveSession(
+          'user-nikhil',
+          {
+            sessionId: 'session-workshop-debugging',
+            eventId,
+            roomId: 'room-workshop-clinic',
+            speakerId: 'speaker-workshop-priya',
+            startsAt: '2026-12-05T05:00:00.000Z',
+            endsAt: '2026-12-05T06:00:00.000Z',
+            capacity: 28,
+            title: 'Conflicting edit',
+            summary: 'Priya is already speaking in the studio.',
+          },
+          '2026-09-08T10:00:00.000Z',
+        )
+        .pipe(Effect.flip);
+      expect(failed.reason.cause).toMatchObject({ message: 'programme speaker conflict' });
+      const after = yield* repository.loadEditor('user-nikhil', eventId);
+      expect(after?.sessions).toEqual(before?.sessions);
+    }).pipe(Effect.provide(RepositoryLayer)),
+  );
+
+  it.effect('leaves the speaker assignment intact when the editor is unauthorized', () =>
+    Effect.gen(function* () {
+      const repository = yield* ProgrammeRepository;
+      const eventId = 'event-rsc-workshop-lab-2026';
+      const before = yield* repository.loadEditor('user-nikhil', eventId);
+      const sessionId = yield* repository.saveSession(
+        'user-maya',
+        {
+          sessionId: 'session-workshop-debugging',
+          eventId,
+          roomId: 'room-workshop-clinic',
+          speakerId: 'speaker-workshop-priya',
+          startsAt: '2026-12-05T09:00:00.000Z',
+          endsAt: '2026-12-05T10:00:00.000Z',
+          capacity: 28,
+          title: 'Unauthorized edit',
+          summary: 'This must not be saved.',
+        },
+        '2026-09-08T10:00:00.000Z',
+      );
+      expect(sessionId).toBeNull();
+      const after = yield* repository.loadEditor('user-nikhil', eventId);
+      expect(after?.sessions).toEqual(before?.sessions);
+    }).pipe(Effect.provide(RepositoryLayer)),
+  );
+
   it.effect('only exposes published sessions for a public event', () =>
     Effect.gen(function* () {
       const repository = yield* ProgrammeRepository;


### PR DESCRIPTION
The event-platform example saved venue-local ticket sale times without converting the fields read by SQLite, rejected valid combined schedule/speaker edits against the previous speaker, and allowed event edits to invalidate existing sessions. Product E2Es also reused mutated seed data across journeys.

- Write ticket sale instants into `salesStartsAt` / `salesEndsAt`, and migrate older local values using the owning event’s timezone. UTC values remain unchanged.
- Replace speaker assignments within the schedule transaction so constraints check the requested final state, with rollback on conflict and authorization preserved.
- Enforce session/event date and capacity bounds in both write directions in SQLite. Return a typed, actionable error from the event editor.
- Give every product browser journey a fresh application process and in-memory database, including retries. Preserve production/development coverage, document the lifecycle, and retain product traces and server logs in CI failure artifacts.

Validation: new regressions failed before the fixes. Root `bun run check`, `bun run build`, and `bun run test` passed: 352 unit tests and 101 browser tests, with 13 existing framework skips. The reporting/refund pair also passed twice in each server mode (8 cases).

Starting a server per journey adds startup work, especially in development; the product suite remains serialized. Legacy sale-time repair uses the event’s current timezone and rejects ambiguous/invalid local times instead of guessing. Existing programme records are preserved; the new constraints govern subsequent writes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Event updates and programme sessions now enforce event date and capacity limits.
  - Ticket sale times are stored consistently in UTC while respecting the event’s local timezone.
  - Invalid programme changes now provide a clear corrective message.

- **Bug Fixes**
  - Improved session and speaker assignment updates, including safer handling of failed or unauthorized edits.
  - Ticket sale times entered during event creation or editing are preserved accurately.

- **Documentation**
  - Updated event-platform guidance for ticket times, event editing rules, and isolated end-to-end test journeys.

- **Tests**
  - Expanded integration and end-to-end coverage for programme constraints, ticket sales, migrations, permissions, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->