### PR TITLE
fix(client): retire skipped renders and preserve stream ownership

### DIFF
--- a/docs/architecture/client-router.md
+++ b/docs/architecture/client-router.md
@@ -233,8 +233,9 @@ type RendererNavigation = {
 - `discard` requests cancellation before commit and resolves once the scheduled tree cannot commit.
   Discarding an already-retired tree is a no-op, so late cancellation cannot restore stale UI.
 
-Refresh cancellation may race with its UI commit. A refresh's `discard` therefore leaves an
-already-visible tree intact and waits for its retirement instead.
+Navigation and refresh cancellation may arrive after React commits but before the caller observes
+the commit notification. In both cases, `discard` leaves the visible tree intact and waits for its
+retirement instead.
 
 React can skip queued replacement renders, including discard renders. Committing a later publication
 also retires earlier skipped updates. Scheduling a replacement alone does not permit release, and

--- a/docs/architecture/client-router.md
+++ b/docs/architecture/client-router.md
@@ -196,8 +196,8 @@ The closed lifecycle event family is:
 - `FlightFailed`
 - `NavigationAborted`
 
-`RenderRetired` is distinct from `NavigationAborted`: the former is React's proof that a visible
-tree is no longer mounted, while the latter is the native precommit signal. This distinction lets a
+`RenderRetired` is distinct from `NavigationAborted`: the former confirms that React can no longer
+display the tree, while the latter is the native precommit signal. This distinction lets a
 refresh, HMR update, Server Function tree, or later navigation safely retire a visible navigation.
 
 The reducer returns the next state and at most one tagged command. State is installed before the
@@ -228,11 +228,22 @@ type RendererNavigation = {
 ```
 
 - `committed` resolves from the framework root's layout effect after the render becomes visible.
-- `retired` resolves when any different render commits and the navigation tree is no longer visible.
-- `discard` is legal only before commit and resolves once the scheduled tree cannot commit.
+- `retired` resolves when React can no longer display the tree: it is neither visible nor referenced
+  by a pending publication. This includes updates React skipped entirely.
+- `discard` requests cancellation before commit and resolves once the scheduled tree cannot commit.
+  Discarding an already-retired tree is a no-op, so late cancellation cannot restore stale UI.
 
 Refresh cancellation may race with its UI commit. A refresh's `discard` therefore leaves an
 already-visible tree intact and waits for its retirement instead.
+
+React can skip queued replacement renders, including discard renders. Committing a later publication
+also retires earlier skipped updates. Scheduling a replacement alone does not permit release, and
+newer pending updates remain alive. A queued discard also retains the tree it would restore: React
+may commit an intermediate tree before processing that discard. The retained tree can retire once
+it is neither visible nor referenced by a later publication.
+
+Each retirement observer closes its own response, even after the router has moved to another
+navigation. Commit and retirement notifications do not need a particular order.
 
 The router must finish `discard` before releasing that candidate's Flight resource. The renderer
 does not expose Flight completion, a stable-tree snapshot, history rollback, or navigation status.
@@ -290,7 +301,8 @@ history/UI rollback machinery unless browser evidence shows the race is harmful.
 postcommit Flight lifetime or a global busy flag.
 
 - A visible navigation stream may coexist with a route refresh or Server Function request.
-- A different successful renderer commit retires the visible navigation regardless of its source.
+- A different successful renderer commit can retire the visible navigation regardless of its source,
+  once no pending discard can restore it.
 - A failed refresh leaves the visible navigation and its stream intact.
 - A routed navigation may preempt refresh preparation. Published refreshes retain their response
   scope in the browser runtime until EOF or renderer-confirmed retirement. Cancelling a pending

--- a/packages/effective-rsc/src/client/browser-renderer.ts
+++ b/packages/effective-rsc/src/client/browser-renderer.ts
@@ -8,67 +8,49 @@ export type BrowserRendererNavigation = {
   readonly retired: Promise<void>;
 };
 
-type BrowserRenderUpdate = {
+type InitialRender = {
+  readonly _tag: 'Initial';
+  readonly routeTree: RouteTreeModel;
+};
+
+type RouteRender = {
+  readonly _tag: 'Navigation' | 'Refresh';
+  readonly order: number;
   readonly committed: PromiseWithResolvers<void>;
   readonly retired: PromiseWithResolvers<void>;
   readonly routeTree: RouteTreeModel;
 };
 
-type BrowserRenderPhase = 'Scheduled' | 'DiscardRequested' | 'Visible' | 'Completed' | 'Retired';
+export type BrowserRender =
+  | InitialRender
+  | RouteRender
+  | {
+      readonly _tag: 'Discard';
+      readonly order: number;
+      readonly restore: InitialRender | RouteRender;
+    };
 
-type BrowserRenderOwner =
-  | { readonly _tag: 'Stable' }
-  | { readonly _tag: 'Update'; readonly update: BrowserRenderUpdate };
-
-type BrowserRendererLifecycle = {
-  active: BrowserRenderOwner;
-  readonly phases: WeakMap<BrowserRenderUpdate, BrowserRenderPhase>;
-  stableRouteTree: RouteTreeModel;
-  visible: BrowserRenderOwner;
+type LiveRender = {
+  readonly _tag: 'Scheduled' | 'DiscardRequested' | 'Committed';
+  readonly lastPublicationOrder: number;
 };
 
 type BrowserRendererState =
   | { readonly _tag: 'Uninitialized' }
   | {
       readonly _tag: 'Ready';
-      readonly lifecycle: BrowserRendererLifecycle;
+      current: BrowserRender;
+      publicationOrder: number;
+      readonly liveRenders: Map<RouteRender, LiveRender>;
       readonly publish: (render: BrowserRender) => void;
     };
-
-export type BrowserRender =
-  | { readonly _tag: 'Initial'; readonly routeTree: RouteTreeModel }
-  | {
-      readonly _tag: 'Navigation' | 'Refresh';
-      readonly update: BrowserRenderUpdate;
-      readonly routeTree: RouteTreeModel;
-    }
-  | {
-      readonly _tag: 'Discard';
-      readonly update: BrowserRenderUpdate;
-      readonly routeTree: RouteTreeModel;
-      readonly visible: BrowserRenderOwner;
-    };
-
-const getRenderPhase = (lifecycle: BrowserRendererLifecycle, update: BrowserRenderUpdate) => {
-  const phase = lifecycle.phases.get(update);
-  if (phase === undefined) {
-    throw new TypeError('Browser render does not belong to this root.');
-  }
-  return phase;
-};
-
-const retireUpdate = (lifecycle: BrowserRendererLifecycle, update: BrowserRenderUpdate) => {
-  if (getRenderPhase(lifecycle, update) !== 'Retired') {
-    lifecycle.phases.set(update, 'Retired');
-    update.retired.resolve();
-  }
-};
 
 export class BrowserRenderer extends Context.Service<BrowserRenderer>()(
   'ersc/client/BrowserRenderer',
   {
     make: Effect.sync(() => {
       const state = MutableRef.make<BrowserRendererState>({ _tag: 'Uninitialized' });
+      const publications = new WeakSet<BrowserRender>();
       const getReadyState = () => {
         const current = MutableRef.get(state);
         if (current._tag === 'Uninitialized') {
@@ -91,58 +73,66 @@ export class BrowserRenderer extends Context.Service<BrowserRenderer>()(
 
         MutableRef.set(state, {
           _tag: 'Ready',
-          lifecycle: {
-            active: { _tag: 'Stable' },
-            phases: new WeakMap<BrowserRenderUpdate, BrowserRenderPhase>(),
-            stableRouteTree: initialRouteTree,
-            visible: { _tag: 'Stable' },
-          },
+          current: { _tag: 'Initial', routeTree: initialRouteTree },
+          publicationOrder: 0,
+          liveRenders: new Map(),
           publish,
         });
       };
 
+      const publish = (render: BrowserRender) => {
+        publications.add(render);
+        getReadyState().publish(render);
+      };
+
       const schedule = (routeTree: RouteTreeModel, kind: 'Navigation' | 'Refresh') => {
-        const { lifecycle, publish } = getReadyState();
-        const update: BrowserRenderUpdate = {
+        const ready = getReadyState();
+        const order = ++ready.publicationOrder;
+        const render: RouteRender = {
+          _tag: kind,
+          order,
           committed: Promise.withResolvers<void>(),
           retired: Promise.withResolvers<void>(),
           routeTree,
         };
-        lifecycle.phases.set(update, 'Scheduled');
-        lifecycle.active = { _tag: 'Update', update };
-        publish({ _tag: kind, update, routeTree });
+        ready.liveRenders.set(render, { _tag: 'Scheduled', lastPublicationOrder: order });
+        publish(render);
 
         return {
-          committed: update.committed.promise,
+          committed: render.committed.promise,
           discard: () => {
-            if (getRenderPhase(lifecycle, update) !== 'Scheduled') {
-              // Refresh cancellation can arrive just after React commits. Its visible tree
-              // must survive until a successor commits, even if the caller has moved on.
-              if (kind === 'Refresh') {
-                return update.retired.promise;
+            const live = ready.liveRenders.get(render);
+            // A successor may have already retired this tree before cancellation arrives.
+            if (live === undefined) {
+              return render.retired.promise;
+            }
+            if (live._tag !== 'Scheduled') {
+              // A committed refresh keeps its stream until React can no longer display it.
+              if (kind === 'Navigation') {
+                throw new TypeError('Only a scheduled browser navigation can be discarded.');
               }
-              throw new TypeError('Only a scheduled browser navigation can be discarded.');
+              return render.retired.promise;
             }
-            lifecycle.phases.set(update, 'DiscardRequested');
-            if (lifecycle.active._tag === 'Update' && lifecycle.active.update === update) {
-              const visible = lifecycle.visible;
-              lifecycle.active =
-                visible._tag === 'Update' && getRenderPhase(lifecycle, visible.update) === 'Visible'
-                  ? visible
-                  : { _tag: 'Stable' };
-            }
-            publish({
-              _tag: 'Discard',
-              update,
-              routeTree:
-                lifecycle.visible._tag === 'Update'
-                  ? lifecycle.visible.update.routeTree
-                  : lifecycle.stableRouteTree,
-              visible: lifecycle.visible,
+            ready.liveRenders.set(render, {
+              _tag: 'DiscardRequested',
+              lastPublicationOrder: order,
             });
-            return update.retired.promise;
+            const current = ready.current;
+            const restore = current._tag === 'Discard' ? current.restore : current;
+            const discardOrder = ++ready.publicationOrder;
+            if (restore._tag !== 'Initial') {
+              // Keep the tree alive even if another render commits before this discard.
+              // Reinsertion keeps the map ordered by each render's last publication.
+              ready.liveRenders.delete(restore);
+              ready.liveRenders.set(restore, {
+                _tag: 'Committed',
+                lastPublicationOrder: discardOrder,
+              });
+            }
+            publish({ _tag: 'Discard', order: discardOrder, restore });
+            return render.retired.promise;
           },
-          retired: update.retired.promise,
+          retired: render.retired.promise,
         };
       };
 
@@ -150,41 +140,43 @@ export class BrowserRenderer extends Context.Service<BrowserRenderer>()(
       const refresh = (routeTree: RouteTreeModel) => schedule(routeTree, 'Refresh');
 
       const commit = (render: BrowserRender) => {
-        const { lifecycle } = getReadyState();
-        const previousVisible = lifecycle.visible;
-        const visible: BrowserRenderOwner =
-          render._tag === 'Navigation' || render._tag === 'Refresh'
-            ? { _tag: 'Update', update: render.update }
-            : render._tag === 'Discard'
-              ? render.visible
-              : { _tag: 'Stable' };
-        lifecycle.visible = visible;
-
-        if (
-          previousVisible._tag === 'Update' &&
-          (visible._tag !== 'Update' || visible.update !== previousVisible.update)
-        ) {
-          retireUpdate(lifecycle, previousVisible.update);
+        const ready = getReadyState();
+        if (render._tag === 'Initial') {
+          return;
+        }
+        if (!publications.has(render)) {
+          throw new TypeError('Browser render does not belong to this root.');
+        }
+        const current = ready.current;
+        if (current._tag !== 'Initial' && render.order < current.order) {
+          throw new TypeError('Browser renders must commit in publication order.');
+        }
+        const visible = render._tag === 'Discard' ? render.restore : render;
+        if (visible._tag !== 'Initial') {
+          const live = ready.liveRenders.get(visible);
+          if (live === undefined) {
+            throw new TypeError('A retired browser tree cannot commit.');
+          }
+          ready.liveRenders.set(visible, {
+            _tag: 'Committed',
+            lastPublicationOrder: live.lastPublicationOrder,
+          });
+        }
+        ready.current = render;
+        if (render._tag !== 'Discard') {
+          render.committed.resolve();
         }
 
-        switch (render._tag) {
-          case 'Initial':
+        // A later replacement commit supersedes earlier publications. A tree stays alive
+        // while visible or referenced by a newer publication, including a pending discard.
+        for (const [retained, live] of ready.liveRenders) {
+          if (live.lastPublicationOrder > render.order) {
             break;
-          case 'Discard':
-            retireUpdate(lifecycle, render.update);
-            break;
-          case 'Navigation':
-          case 'Refresh':
-            if (getRenderPhase(lifecycle, render.update) === 'Scheduled') {
-              lifecycle.phases.set(render.update, 'Visible');
-            }
-            if (lifecycle.active._tag === 'Update' && lifecycle.active.update === render.update) {
-              lifecycle.active = { _tag: 'Stable' };
-              lifecycle.stableRouteTree = render.routeTree;
-              lifecycle.phases.set(render.update, 'Completed');
-            }
-            render.update.committed.resolve();
-            break;
+          }
+          if (retained !== visible) {
+            ready.liveRenders.delete(retained);
+            retained.retired.resolve();
+          }
         }
       };
 

--- a/packages/effective-rsc/src/client/browser-renderer.ts
+++ b/packages/effective-rsc/src/client/browser-renderer.ts
@@ -102,15 +102,8 @@ export class BrowserRenderer extends Context.Service<BrowserRenderer>()(
           committed: render.committed.promise,
           discard: () => {
             const live = ready.liveRenders.get(render);
-            // A successor may have already retired this tree before cancellation arrives.
-            if (live === undefined) {
-              return render.retired.promise;
-            }
-            if (live._tag !== 'Scheduled') {
-              // A committed refresh keeps its stream until React can no longer display it.
-              if (kind === 'Navigation') {
-                throw new TypeError('Only a scheduled browser navigation can be discarded.');
-              }
+            // Cancellation can arrive before the caller observes a commit or retirement.
+            if (live?._tag !== 'Scheduled') {
               return render.retired.promise;
             }
             ready.liveRenders.set(render, {

--- a/packages/effective-rsc/src/client/client-router.ts
+++ b/packages/effective-rsc/src/client/client-router.ts
@@ -167,10 +167,7 @@ const reduceRouterState = (state: RouterState, event: RouterEvent): RouterTransi
     switch (event._tag) {
       case 'RenderRetired':
         return {
-          command:
-            visible.flight._tag === 'Streaming'
-              ? { _tag: 'ReleaseRoute', resource: visible.flight.resource }
-              : null,
+          command: null,
           state: { ...state, visible: { _tag: 'Settled' } },
         };
       case 'HistoryCommitted':
@@ -596,9 +593,12 @@ export const installClientRouter = Effect.gen(function* () {
 
       const waitForRenderRetirement = Effect.gen(function* () {
         yield* Effect.promise(() => rendererNavigation.retired);
-        const transition = dispatch({ _tag: 'RenderRetired', generation });
-        yield* executeRouterCommand(transition.command);
-      }).pipe(Effect.ignore);
+        dispatch({ _tag: 'RenderRetired', generation });
+      }).pipe(
+        // A newer generation may already be current when this render retires.
+        Effect.ensuring(resource.release),
+        Effect.ignore,
+      );
       void run(waitForRenderRetirement).catch(() => undefined);
 
       const waitForFlightCompletion = Effect.gen(function* () {

--- a/packages/effective-rsc/src/client/react-dom-renderer.tsx
+++ b/packages/effective-rsc/src/client/react-dom-renderer.tsx
@@ -122,9 +122,10 @@ export class ReactDOMRenderer extends Context.Service<ReactDOMRenderer>()(
             browserRenderer.commit(render);
           }, [render]);
 
+          const routeTree = render._tag === 'Discard' ? render.restore.routeTree : render.routeTree;
           return (
             <BrowserErrorBoundary onError={reportError} onRendered={reportRendered} render={render}>
-              <RouteTree root={render.routeTree} />
+              <RouteTree root={routeTree} />
             </BrowserErrorBoundary>
           );
         }

--- a/packages/effective-rsc/tests/client/browser-renderer.test.ts
+++ b/packages/effective-rsc/tests/client/browser-renderer.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from '@effect/vitest';
 import { Effect } from 'effect';
+import { vi } from 'vitest';
 
 import { type BrowserRender, BrowserRenderer } from '../../src/client/browser-renderer';
 import type { RouteTreeModel } from '../../src/rsc/route-tree';
@@ -132,8 +133,10 @@ it.effect('discards a scheduled navigation without replacing the visible navigat
     nextRender(renders);
     const discarded = candidate.discard();
     const discardRender = nextRender(renders);
-    expect(discardRender._tag).toBe('Discard');
-    expect(discardRender.routeTree).toBe(visibleRouteTree);
+    if (discardRender._tag !== 'Discard') {
+      return yield* Effect.die('Expected a discard render.');
+    }
+    expect(discardRender.restore.routeTree).toBe(visibleRouteTree);
 
     let candidateRetired = false;
     let visibleRetired = false;
@@ -151,13 +154,12 @@ it.effect('discards a scheduled navigation without replacing the visible navigat
 
     expect(candidateRetired).toBe(true);
     expect(visibleRetired).toBe(false);
-    expect(() => candidate.discard()).toThrow(
-      'Only a scheduled browser navigation can be discarded.',
-    );
+    expect(candidate.discard()).toBe(discarded);
+    expect(renders).toEqual([]);
   }).pipe(Effect.provide(BrowserRenderer.layer)),
 );
 
-it.effect('advances the stable route tree when a navigation commits', () =>
+it.effect('restores the last committed tree when discarding the next navigation', () =>
   Effect.gen(function* () {
     const firstRouteTree = makeRouteTree('first');
     const renders: Array<BrowserRender> = [];
@@ -181,7 +183,7 @@ it.effect('advances the stable route tree when a navigation commits', () =>
       return yield* Effect.die('Expected a discard render.');
     }
 
-    expect(discardRender.routeTree).toBe(firstRouteTree);
+    expect(discardRender.restore.routeTree).toBe(firstRouteTree);
     renderer.commit(discardRender);
     yield* Effect.promise(() => retired);
   }).pipe(Effect.provide(BrowserRenderer.layer)),
@@ -212,8 +214,231 @@ it.effect('uses a committed Server Function refresh as the next discard target',
       return yield* Effect.die('Expected a discard render.');
     }
 
-    expect(discardRender.routeTree).toBe(refreshedRouteTree);
+    expect(discardRender.restore.routeTree).toBe(refreshedRouteTree);
     renderer.commit(discardRender);
     yield* Effect.promise(() => retired);
+  }).pipe(Effect.provide(BrowserRenderer.layer)),
+);
+
+it.effect('retires skipped refreshes only up to the render React commits', () =>
+  Effect.gen(function* () {
+    const renderer = yield* BrowserRenderer;
+    const renders: Array<BrowserRender> = [];
+    renderer.initialize(makeRouteTree('initial'), (render) => renders.push(render));
+    const first = renderer.refresh(makeRouteTree('first'));
+    nextRender(renders);
+    const second = renderer.refresh(makeRouteTree('second'));
+    const secondRender = nextRender(renders);
+    const third = renderer.refresh(makeRouteTree('third'));
+    const thirdRender = nextRender(renders);
+    const firstRetired = vi.fn();
+    const firstCommitted = vi.fn();
+    const secondRetired = vi.fn();
+    const thirdRetired = vi.fn();
+    void first.retired.then(firstRetired);
+    void first.committed.then(firstCommitted);
+    void second.retired.then(secondRetired);
+    void third.retired.then(thirdRetired);
+
+    yield* Effect.promise(() => Promise.resolve());
+    expect(firstRetired).not.toHaveBeenCalled();
+
+    // React skips the first refresh, while the third is still preparing.
+    renderer.commit(secondRender);
+    yield* Effect.promise(() => second.committed);
+    expect(firstRetired).toHaveBeenCalledOnce();
+    expect(firstCommitted).not.toHaveBeenCalled();
+    expect(secondRetired).not.toHaveBeenCalled();
+    expect(thirdRetired).not.toHaveBeenCalled();
+
+    // React may repeat a layout effect; the same commit must remain harmless.
+    renderer.commit(secondRender);
+    renderer.commit(thirdRender);
+    yield* Effect.promise(() => third.committed);
+    expect(secondRetired).toHaveBeenCalledOnce();
+    expect(thirdRetired).not.toHaveBeenCalled();
+  }).pipe(Effect.provide(BrowserRenderer.layer)),
+);
+
+it.effect('acknowledges a discard that React skips when committing a replacement', () =>
+  Effect.gen(function* () {
+    const renderer = yield* BrowserRenderer;
+    const renders: Array<BrowserRender> = [];
+    renderer.initialize(makeRouteTree('initial'), (render) => renders.push(render));
+    const first = renderer.refresh(makeRouteTree('first'));
+    nextRender(renders);
+    const discarded = vi.fn();
+    void first.discard().then(discarded);
+    expect(nextRender(renders)._tag).toBe('Discard');
+    const second = renderer.refresh(makeRouteTree('second'));
+    const secondRender = nextRender(renders);
+
+    yield* Effect.promise(() => Promise.resolve());
+    expect(discarded).not.toHaveBeenCalled();
+    renderer.commit(secondRender);
+    yield* Effect.promise(() => second.committed);
+    expect(discarded).toHaveBeenCalledOnce();
+  }).pipe(Effect.provide(BrowserRenderer.layer)),
+);
+
+it.effect('uses discard publication order when retiring skipped renders', () =>
+  Effect.gen(function* () {
+    const renderer = yield* BrowserRenderer;
+    const renders: Array<BrowserRender> = [];
+    renderer.initialize(makeRouteTree('initial'), (render) => renders.push(render));
+    const first = renderer.refresh(makeRouteTree('first'));
+    nextRender(renders);
+    const second = renderer.refresh(makeRouteTree('second'));
+    nextRender(renders);
+    const discarded = first.discard();
+    const discardRender = nextRender(renders);
+    const third = renderer.refresh(makeRouteTree('third'));
+    nextRender(renders);
+    const secondRetired = vi.fn();
+    const thirdRetired = vi.fn();
+    void second.retired.then(secondRetired);
+    void third.retired.then(thirdRetired);
+
+    // This discard was published after the second refresh but before the third.
+    renderer.commit(discardRender);
+    yield* Effect.promise(() => discarded);
+    expect(secondRetired).toHaveBeenCalledOnce();
+    expect(thirdRetired).not.toHaveBeenCalled();
+  }).pipe(Effect.provide(BrowserRenderer.layer)),
+);
+
+it.effect(
+  'does not republish a skipped navigation when cancellation arrives after retirement',
+  () =>
+    Effect.gen(function* () {
+      const renderer = yield* BrowserRenderer;
+      const renders: Array<BrowserRender> = [];
+      renderer.initialize(makeRouteTree('initial'), (render) => renders.push(render));
+      const navigation = renderer.navigate(makeRouteTree('destination'));
+      nextRender(renders);
+      const refresh = renderer.refresh(makeRouteTree('refreshed'));
+      renderer.commit(nextRender(renders));
+      yield* Effect.promise(() => refresh.committed);
+
+      expect(navigation.discard()).toBe(navigation.retired);
+      expect(renders).toEqual([]);
+    }).pipe(Effect.provide(BrowserRenderer.layer)),
+);
+
+it.effect('keeps a tree alive while a queued discard can restore it', () =>
+  Effect.gen(function* () {
+    const renderer = yield* BrowserRenderer;
+    const renders: Array<BrowserRender> = [];
+    renderer.initialize(makeRouteTree('initial'), (render) => renders.push(render));
+    const visible = renderer.refresh(makeRouteTree('visible'));
+    renderer.commit(nextRender(renders));
+    const visibleRetired = vi.fn();
+    void visible.retired.then(visibleRetired);
+
+    const candidate = renderer.refresh(makeRouteTree('candidate'));
+    const candidateRender = nextRender(renders);
+    const discarded = candidate.discard();
+    const discardRender = nextRender(renders);
+
+    // React commits the candidate before processing its lower-priority discard.
+    // The discard still needs the previous page's stream to restore that page.
+    renderer.commit(candidateRender);
+    yield* Effect.promise(() => candidate.committed);
+    expect(visibleRetired).not.toHaveBeenCalled();
+
+    renderer.commit(discardRender);
+    yield* Effect.promise(() => discarded);
+    expect(visibleRetired).not.toHaveBeenCalled();
+
+    const replacement = renderer.refresh(makeRouteTree('replacement'));
+    renderer.commit(nextRender(renders));
+    yield* Effect.promise(() => replacement.committed);
+    expect(visibleRetired).toHaveBeenCalledOnce();
+  }).pipe(Effect.provide(BrowserRenderer.layer)),
+);
+
+it.effect('releases a retained tree when React skips the discard that would restore it', () =>
+  Effect.gen(function* () {
+    const renderer = yield* BrowserRenderer;
+    const renders: Array<BrowserRender> = [];
+    renderer.initialize(makeRouteTree('initial'), (render) => renders.push(render));
+    const visible = renderer.refresh(makeRouteTree('visible'));
+    renderer.commit(nextRender(renders));
+    const visibleRetired = vi.fn();
+    void visible.retired.then(visibleRetired);
+
+    const candidate = renderer.refresh(makeRouteTree('candidate'));
+    const candidateRender = nextRender(renders);
+    const candidateRetired = vi.fn();
+    void candidate.discard().then(candidateRetired);
+    nextRender(renders);
+    renderer.commit(candidateRender);
+    yield* Effect.promise(() => candidate.committed);
+    expect(visibleRetired).not.toHaveBeenCalled();
+
+    // A newer replacement overtakes the discard, so neither older tree can return.
+    const replacement = renderer.refresh(makeRouteTree('replacement'));
+    renderer.commit(nextRender(renders));
+    yield* Effect.promise(() => replacement.committed);
+    expect(visibleRetired).toHaveBeenCalledOnce();
+    expect(candidateRetired).toHaveBeenCalledOnce();
+  }).pipe(Effect.provide(BrowserRenderer.layer)),
+);
+
+it.effect("rejects another root's publication before changing the visible tree", () =>
+  Effect.gen(function* () {
+    const renderer = yield* BrowserRenderer.make;
+    const otherRenderer = yield* BrowserRenderer.make;
+    const renders: Array<BrowserRender> = [];
+    const otherRenders: Array<BrowserRender> = [];
+    renderer.initialize(makeRouteTree('initial'), (render) => renders.push(render));
+    otherRenderer.initialize(makeRouteTree('other'), (render) => otherRenders.push(render));
+    const visibleTree = makeRouteTree('visible');
+    const visible = renderer.refresh(visibleTree);
+    renderer.commit(nextRender(renders));
+    const visibleRetired = vi.fn();
+    void visible.retired.then(visibleRetired);
+
+    otherRenderer.refresh(makeRouteTree('foreign'));
+    expect(() => renderer.commit(nextRender(otherRenders))).toThrow(
+      'Browser render does not belong to this root.',
+    );
+
+    const candidate = renderer.navigate(makeRouteTree('candidate'));
+    nextRender(renders);
+    const discarded = candidate.discard();
+    const discardRender = nextRender(renders);
+    if (discardRender._tag !== 'Discard') {
+      return yield* Effect.die('Expected a discard render.');
+    }
+    expect(discardRender.restore.routeTree).toBe(visibleTree);
+    renderer.commit(discardRender);
+    yield* Effect.promise(() => discarded);
+    expect(visibleRetired).not.toHaveBeenCalled();
+  }),
+);
+
+it.effect('rejects an older commit without retiring the current tree', () =>
+  Effect.gen(function* () {
+    const renderer = yield* BrowserRenderer;
+    const renders: Array<BrowserRender> = [];
+    renderer.initialize(makeRouteTree('initial'), (render) => renders.push(render));
+    renderer.refresh(makeRouteTree('skipped'));
+    const skippedRender = nextRender(renders);
+    const current = renderer.refresh(makeRouteTree('current'));
+    renderer.commit(nextRender(renders));
+    const currentRetired = vi.fn();
+    void current.retired.then(currentRetired);
+
+    expect(() => renderer.commit(skippedRender)).toThrow(
+      'Browser renders must commit in publication order.',
+    );
+    yield* Effect.promise(() => current.committed);
+    expect(currentRetired).not.toHaveBeenCalled();
+
+    const replacement = renderer.refresh(makeRouteTree('replacement'));
+    renderer.commit(nextRender(renders));
+    yield* Effect.promise(() => replacement.committed);
+    expect(currentRetired).toHaveBeenCalledOnce();
   }).pipe(Effect.provide(BrowserRenderer.layer)),
 );

--- a/packages/effective-rsc/tests/client/browser-renderer.test.ts
+++ b/packages/effective-rsc/tests/client/browser-renderer.test.ts
@@ -34,7 +34,7 @@ it.effect('initializes once for a React root', () =>
   }).pipe(Effect.provide(BrowserRenderer.layer)),
 );
 
-it.effect('rejects discard after a navigation commits', () =>
+it.effect('waits for retirement when a navigation is discarded after commit', () =>
   Effect.gen(function* () {
     const renders: Array<BrowserRender> = [];
     const renderer = yield* BrowserRenderer;
@@ -47,10 +47,20 @@ it.effect('rejects discard after a navigation commits', () =>
     renderer.commit(navigationRender);
     yield* Effect.promise(() => navigation.committed);
 
-    expect(() => navigation.discard()).toThrow(
-      'Only a scheduled browser navigation can be discarded.',
-    );
+    const discarded = vi.fn();
+    const retirement = navigation.discard();
+    void retirement.then(discarded);
+    expect(navigation.discard()).toBe(retirement);
     expect(renders).toEqual([]);
+
+    renderer.navigate(makeRouteTree('successor'));
+    const successor = nextRender(renders);
+    yield* Effect.yieldNow;
+    expect(discarded).not.toHaveBeenCalled();
+
+    renderer.commit(successor);
+    yield* Effect.promise(() => retirement);
+    expect(discarded).toHaveBeenCalledOnce();
   }).pipe(Effect.provide(BrowserRenderer.layer)),
 );
 

--- a/packages/effective-rsc/tests/client/call-server.test.ts
+++ b/packages/effective-rsc/tests/client/call-server.test.ts
@@ -455,3 +455,59 @@ it.effect('releases a visible Server Function refresh when its replacement commi
     ),
   ),
 );
+
+it.effect('releases a never-committed Server Function refresh after its successor commits', () =>
+  Effect.gen(function* () {
+    const browserRenderer = yield* BrowserRenderer.make;
+    let published = Promise.withResolvers<BrowserRender>();
+    browserRenderer.initialize(makeRouteTree('initial'), (render) => published.resolve(render));
+    const released = vi.fn();
+    const cached = vi.fn();
+    yield* listen(
+      Layer.mergeAll(
+        BrowserEffectRunner.layer,
+        BrowserRenderer.layerTest(browserRenderer),
+        FlightClient.layerTest({
+          load: () => Effect.succeed(makeFlight('refreshed', 'saved', Effect.sync(released))),
+        }),
+        NavigationApi.layerTest({
+          getCurrentEntry: () => firstEntry,
+          getCurrentUrl: () => firstEntry.url,
+          getTransition: () => null,
+          navigate: () => {
+            throw new TypeError('Unexpected document navigation.');
+          },
+          reloadDocument: () => undefined,
+          replaceDocument: () => undefined,
+          subscribe: () => () => undefined,
+        }),
+        RouteLoader.layerTest({ invalidate: () => undefined, prepareRefresh: () => cached }),
+        RouteRefresher.layerTest({ interruptCurrentRouteRefresh: Effect.void }),
+      ),
+    );
+
+    const result = yield* Effect.promise(() => invokeServerFn('save'));
+    expect(result).toBe('saved');
+    const refresh = yield* Effect.promise(() => published.promise);
+    expect(refresh._tag).toBe('Refresh');
+
+    // The first stream has ended, but React has not committed its refresh.
+    published = Promise.withResolvers<BrowserRender>();
+    const replacement = browserRenderer.refresh(makeRouteTree('replacement'));
+    const nextRender = yield* Effect.promise(() => published.promise);
+    yield* Effect.yieldNow;
+    expect(released).not.toHaveBeenCalled();
+
+    browserRenderer.commit(nextRender);
+    yield* Effect.promise(() => replacement.committed);
+    yield* Effect.yieldNow;
+    expect(released).toHaveBeenCalledOnce();
+    expect(cached).not.toHaveBeenCalled();
+  }).pipe(
+    Effect.scoped,
+    Effect.provideService(
+      HttpClient.HttpClient,
+      HttpClient.make(() => Effect.die('Unexpected HTTP request.')),
+    ),
+  ),
+);

--- a/packages/effective-rsc/tests/client/client-router.test.ts
+++ b/packages/effective-rsc/tests/client/client-router.test.ts
@@ -1422,6 +1422,63 @@ it.effect(
     ),
 );
 
+it.effect(
+  'keeps a committed navigation stream alive when superseded before its commit notification',
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const navigation = new TestNavigationApi();
+        const renderer = yield* BrowserRenderer.make;
+        let published = Promise.withResolvers<BrowserRender>();
+        renderer.initialize(initialRouteTree, (render) => published.resolve(render));
+        const { httpClient, responseSignals } = makeStreamingHttpClient();
+        yield* listen(navigation, renderer, httpClient);
+
+        const first = makeNavigationEvent();
+        navigation.dispatch(first.event);
+        const firstHandler = first.interception()?.precommitHandler;
+        if (firstHandler === undefined) {
+          return yield* Effect.die('Expected a precommit handler for the first navigation.');
+        }
+        const firstPreparation = yield* Effect.promise(() =>
+          invokePrecommitHandler(firstHandler, makePrecommitController()),
+        ).pipe(Effect.forkChild);
+        const firstRender = yield* Effect.promise(() => published.promise);
+        yield* Effect.yieldNow;
+
+        const successor = makeNavigationEvent({
+          destination: { url: 'https://effective-rsc.test/schedule/day-three' },
+        });
+        // A child layout effect can queue navigation before the root resolves committed.
+        // That microtask then runs before the router processes the commit notification.
+        queueMicrotask(() => navigation.dispatch(successor.event));
+        renderer.commit(firstRender);
+        yield* Fiber.join(firstPreparation);
+        yield* Effect.yieldNow;
+
+        expect(responseSignals).toHaveLength(1);
+        expect(responseSignals[0]?.aborted).toBe(false);
+
+        const successorHandler = successor.interception()?.precommitHandler;
+        if (successorHandler === undefined) {
+          return yield* Effect.die('Expected a precommit handler for the successor.');
+        }
+        published = Promise.withResolvers<BrowserRender>();
+        const successorPreparation = yield* Effect.promise(() =>
+          invokePrecommitHandler(successorHandler, makePrecommitController()),
+        ).pipe(Effect.forkChild);
+        const successorRender = yield* Effect.promise(() => published.promise);
+        expect(responseSignals[0]?.aborted).toBe(false);
+
+        renderer.commit(successorRender);
+        yield* Fiber.join(successorPreparation);
+        yield* Effect.yieldNow;
+        expect(responseSignals[0]?.aborted).toBe(true);
+        expect(responseSignals[1]?.aborted).toBe(false);
+      }),
+    ),
+);
+
 it.effect('keeps an older navigation stream while a queued discard can restore it', () =>
   Effect.scoped(
     Effect.gen(function* () {

--- a/packages/effective-rsc/tests/client/client-router.test.ts
+++ b/packages/effective-rsc/tests/client/client-router.test.ts
@@ -35,7 +35,7 @@ vi.mock('react-server-dom-rspack/client.browser', () => ({
 }));
 
 import { BrowserEffectRunner } from '../../src/client/browser-effect-runner';
-import { BrowserRenderer } from '../../src/client/browser-renderer';
+import { type BrowserRender, BrowserRenderer } from '../../src/client/browser-renderer';
 import { installClientRouter } from '../../src/client/client-router';
 import { FlightClient } from '../../src/client/flight-client';
 import { InitialFlightStream } from '../../src/client/initial-flight-stream';
@@ -220,6 +220,35 @@ const makeInvalidFlightClient = () =>
       ),
     ),
   );
+
+const makeStreamingHttpClient = () => {
+  const responseSignals: Array<AbortSignal> = [];
+  const httpClient = HttpClient.make((request, _url, signal) =>
+    Effect.sync(() => {
+      responseSignals.push(signal);
+      return HttpClientResponse.fromWeb(
+        request,
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array([1]));
+              signal.addEventListener('abort', () => controller.error(signal.reason), {
+                once: true,
+              });
+            },
+          }),
+          {
+            headers: {
+              'content-location': request.url,
+              'content-type': 'text/x-component',
+            },
+          },
+        ),
+      );
+    }),
+  );
+  return { httpClient, responseSignals };
+};
 
 type BrowserRenderRequest = {
   readonly _tag: 'Navigation' | 'ServerFunction';
@@ -1348,4 +1377,106 @@ it.effect('removes the listener when its Effect scope closes', () =>
 
     expect(navigation.isListening).toBe(false);
   }),
+);
+
+it.effect(
+  'releases the previous navigation stream when the real renderer commits its successor',
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const navigation = new TestNavigationApi();
+        const renderer = yield* BrowserRenderer.make;
+        let published = Promise.withResolvers<BrowserRender>();
+        renderer.initialize(initialRouteTree, (render) => published.resolve(render));
+        const { httpClient, responseSignals } = makeStreamingHttpClient();
+        yield* listen(navigation, renderer, httpClient);
+
+        const firstUrl = 'https://effective-rsc.test/schedule/day-two';
+        const firstPreparation = yield* prepareNavigation(navigation, firstUrl).pipe(
+          Effect.forkChild,
+        );
+        const firstRender = yield* Effect.promise(() => published.promise);
+        yield* Effect.yieldNow;
+        renderer.commit(firstRender);
+        const firstHistory = yield* Fiber.join(firstPreparation);
+        navigation.currentEntry = makeNavigationEntry('day-two', firstUrl);
+        yield* Effect.promise(() => invokeNavigationHandler(firstHistory));
+
+        published = Promise.withResolvers<BrowserRender>();
+        const secondPreparation = yield* prepareNavigation(
+          navigation,
+          'https://effective-rsc.test/schedule/day-three',
+        ).pipe(Effect.forkChild);
+        const secondRender = yield* Effect.promise(() => published.promise);
+        yield* Effect.yieldNow;
+        expect(responseSignals[0]?.aborted).toBe(false);
+
+        // Both router observers are waiting when React commits the successor.
+        // The old stream must close even if the new generation becomes current first.
+        renderer.commit(secondRender);
+        yield* Fiber.join(secondPreparation);
+        yield* Effect.yieldNow;
+        expect(responseSignals[0]?.aborted).toBe(true);
+        expect(responseSignals[1]?.aborted).toBe(false);
+      }),
+    ),
+);
+
+it.effect('keeps an older navigation stream while a queued discard can restore it', () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const navigation = new TestNavigationApi();
+      const renderer = yield* BrowserRenderer.make;
+      let published = Promise.withResolvers<BrowserRender>();
+      renderer.initialize(initialRouteTree, (render) => published.resolve(render));
+      const { httpClient, responseSignals } = makeStreamingHttpClient();
+      yield* listen(navigation, renderer, httpClient);
+
+      const firstUrl = 'https://effective-rsc.test/schedule/day-two';
+      const firstPreparation = yield* prepareNavigation(navigation, firstUrl).pipe(
+        Effect.forkChild,
+      );
+      const firstRender = yield* Effect.promise(() => published.promise);
+      yield* Effect.yieldNow;
+      renderer.commit(firstRender);
+      const firstHistory = yield* Fiber.join(firstPreparation);
+      navigation.currentEntry = makeNavigationEntry('day-two', firstUrl);
+      yield* Effect.promise(() => invokeNavigationHandler(firstHistory));
+
+      published = Promise.withResolvers<BrowserRender>();
+      const secondUrl = 'https://effective-rsc.test/schedule/day-three';
+      const secondPreparation = yield* prepareNavigation(navigation, secondUrl).pipe(
+        Effect.forkChild,
+      );
+      const secondRender = yield* Effect.promise(() => published.promise);
+      yield* Effect.yieldNow;
+
+      // A cancelled refresh queues restoration of the first page before the second commits.
+      const refresh = renderer.refresh(initialRouteTree);
+      published = Promise.withResolvers<BrowserRender>();
+      const discarded = refresh.discard();
+      const discardRender = yield* Effect.promise(() => published.promise);
+      renderer.commit(secondRender);
+      const secondHistory = yield* Fiber.join(secondPreparation);
+      navigation.currentEntry = makeNavigationEntry('day-three', secondUrl);
+      yield* Effect.promise(() => invokeNavigationHandler(secondHistory));
+      expect(responseSignals[0]?.aborted).toBe(false);
+      expect(responseSignals[1]?.aborted).toBe(false);
+
+      // The router has moved on, but React can still restore the first page.
+      renderer.commit(discardRender);
+      yield* Effect.promise(() => discarded);
+      yield* Effect.yieldNow;
+      expect(responseSignals[0]?.aborted).toBe(false);
+      expect(responseSignals[1]?.aborted).toBe(true);
+
+      // Once the restored page retires, its original observer must release its stream.
+      published = Promise.withResolvers<BrowserRender>();
+      renderer.refresh(initialRouteTree);
+      const replacement = yield* Effect.promise(() => published.promise);
+      renderer.commit(replacement);
+      yield* Effect.yieldNow;
+      expect(responseSignals[0]?.aborted).toBe(true);
+    }),
+  ),
 );

--- a/packages/effective-rsc/tests/client/route-refresh.test.ts
+++ b/packages/effective-rsc/tests/client/route-refresh.test.ts
@@ -365,7 +365,9 @@ it.effect('keeps a visible refresh stream open while the next navigation is pend
         // Commit the refreshed page while its server response is still streaming.
         yield* refresh('server-function');
         const render = yield* Effect.promise(() => published.promise);
-        expect(render._tag).toBe('Refresh');
+        if (render._tag !== 'Refresh') {
+          return yield* Effect.die('Expected a refresh render.');
+        }
         expect(render.routeTree).toBe(refreshedTree);
         browserRenderer.commit(render);
         yield* Effect.yieldNow;
@@ -449,8 +451,10 @@ it.effect('discards an uncommitted refresh before releasing its response', () =>
         published = Promise.withResolvers<BrowserRender>();
         yield* interrupt;
         const discard = yield* Effect.promise(() => published.promise);
-        expect(discard._tag).toBe('Discard');
-        expect(discard.routeTree).toBe(initialTree);
+        if (discard._tag !== 'Discard') {
+          return yield* Effect.die('Expected a discard render.');
+        }
+        expect(discard.restore.routeTree).toBe(initialTree);
         expect(releaseStream).not.toHaveBeenCalled();
         expect(Deferred.isDoneUnsafe(responseScopeClosed)).toBe(false);
 


### PR DESCRIPTION
React can skip a queued refresh entirely, leaving its cleanup waiting for a commit that never happens. A queued discard can also restore an earlier tree after an intermediate render commits, so releasing every replaced tree is unsafe.

Track the last queued publication that can display each render. Retire skipped renders when they become unreachable, retain trees referenced by pending discards, and reject invalid commit notifications before changing state. The render model is flat, with discards referencing the render they restore.

Keep router response cleanup in the owning retirement observer. This closes the old response even when the successor becomes current before the retirement notification arrives. Add regressions using the real renderer and router, including HTTP abort assertions, and clarify the lifecycle contract.

Validation:
- `bun run check` and `bun run build` passed.
- `bun run test`: 363 unit tests and 101 browser tests passed; 13 existing browser skips.
- Local React/Chromium probes passed for skipped transitions and delayed discards.
- An independent full-history model matched 800,000 seeded operations and detected deliberately broken retirement implementations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved client navigation handling when users navigate rapidly or cancel a pending navigation.
  - Prevented outdated or skipped page updates from replacing newer content.
  - Ensured previous pages and streaming responses are released at the correct time.
  - Improved restoration of the prior page when a navigation is discarded.
  - Added safeguards against invalid render ordering and cross-root updates.
  - Improved handling of refreshes and navigation updates that complete out of order.

- **Documentation**
  - Clarified client-router behavior for rendering, cancellation, retirement, and navigation transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->