### PR TITLE
fix(dev): recover from stalled application startup

### DIFF
--- a/docs/architecture/build.md
+++ b/docs/architecture/build.md
@@ -79,6 +79,8 @@ code. Successful replacement interrupts the previous generation's pending handle
 streams before disposing its application services. Saving a file can therefore cut off an active
 response; development does not drain old generations or automatically retry Server Functions.
 Failed candidates leave the current generation's existing requests alone.
+When a rebuild starts, pending application startup is interrupted and cleaned up before the next
+candidate starts. Requests waiting for startup continue waiting for the new compilation outcome.
 Compilation and application startup failures are reported in both the terminal and the development
 panel. A failed candidate never publishes a successful browser update.
 Content-hashed development server bundles and chunks remain available for the development session.

--- a/fixtures/framework-e2e/e2e/development-startup-diagnostics.spec.ts
+++ b/fixtures/framework-e2e/e2e/development-startup-diagnostics.spec.ts
@@ -37,16 +37,15 @@ test('recovers from stalled application startup after a source correction', asyn
         ),
     );
     await expect.poll(() => readFile(startedPath, 'utf8').catch(() => '')).toBe('started');
-
-    await writeFile(applicationPath, original);
-    await expect.poll(() => readFile(closedPath, 'utf8').catch(() => '')).toBe('closed');
-    const response = await request.get('/', { timeout: 10_000 });
-    expect(response.status()).toBe(200);
-    expect(await response.text()).toContain('Runtime probe original');
-    await rm(markers, { recursive: true, force: true });
   } finally {
     await writeFile(applicationPath, original);
+    // The startup finalizer still needs this directory until it writes the cleanup marker.
+    await expect.poll(() => readFile(closedPath, 'utf8').catch(() => '')).toBe('closed');
+    await rm(markers, { recursive: true, force: true });
   }
+  const response = await request.get('/', { timeout: 10_000 });
+  expect(response.status()).toBe(200);
+  expect(await response.text()).toContain('Runtime probe original');
 });
 
 test('reports application startup failure and clears it after successful replacement', async ({

--- a/fixtures/framework-e2e/e2e/development-startup-diagnostics.spec.ts
+++ b/fixtures/framework-e2e/e2e/development-startup-diagnostics.spec.ts
@@ -1,10 +1,53 @@
 // oxlint-disable effecttsgo/async-function -- Playwright owns this Promise-based test boundary.
 // oxlint-disable effecttsgo/node-builtin-import -- Playwright edits and restores watched fixture source within its test lifetime.
-import { readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { expect, test } from '@playwright/test';
 
 const applicationPath = new URL('../src/application.tsx', import.meta.url);
+
+test('recovers from stalled application startup after a source correction', async ({
+  request,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'dev', 'This contract exercises the development server.');
+  const original = await readFile(applicationPath, 'utf8');
+  const markers = await mkdtemp(join(tmpdir(), 'ersc-stalled-startup-'));
+  const startedPath = join(markers, 'started');
+  const closedPath = join(markers, 'closed');
+  try {
+    await writeFile(
+      applicationPath,
+      original
+        .replace(
+          "import { Layer } from 'effect';",
+          "import { Effect, FileSystem, Layer } from 'effect';",
+        )
+        .replace(
+          'Layer.mergeAll(SelectionHttpLayer, PublicHttpLayer)',
+          `Layer.mergeAll(SelectionHttpLayer, PublicHttpLayer, Layer.effectDiscard(
+            Effect.gen(function* () {
+              const fs = yield* FileSystem.FileSystem;
+              yield* Effect.addFinalizer(() => fs.writeFileString(${JSON.stringify(closedPath)}, 'closed').pipe(Effect.orDie));
+              yield* fs.writeFileString(${JSON.stringify(startedPath)}, 'started');
+              yield* Effect.never;
+            })
+          ))`,
+        ),
+    );
+    await expect.poll(() => readFile(startedPath, 'utf8').catch(() => '')).toBe('started');
+
+    await writeFile(applicationPath, original);
+    await expect.poll(() => readFile(closedPath, 'utf8').catch(() => '')).toBe('closed');
+    const response = await request.get('/', { timeout: 10_000 });
+    expect(response.status()).toBe(200);
+    expect(await response.text()).toContain('Runtime probe original');
+    await rm(markers, { recursive: true, force: true });
+  } finally {
+    await writeFile(applicationPath, original);
+  }
+});
 
 test('reports application startup failure and clears it after successful replacement', async ({
   page,

--- a/packages/effective-rsc/src/build/dev.ts
+++ b/packages/effective-rsc/src/build/dev.ts
@@ -3,6 +3,7 @@ import {
   Deferred,
   Effect,
   Fiber,
+  FiberHandle,
   FileSystem,
   Layer,
   Path,
@@ -115,6 +116,7 @@ export const makeDevGenerationStore = Effect.fnUntraced(function* (options: DevG
   const generation = yield* ScopedRef.make<DevGenerationState>(() => ({ _tag: 'Unavailable' }));
   const initialCompilation = yield* Deferred.make<DevGeneration, DevGenerationFailure>();
   const compilation = yield* Ref.make(initialCompilation);
+  // Only acquisition can be cancelled; installation must also release waiting requests.
   const update = Effect.fnUntraced(function* (event: RspackWatchEvent) {
     const current = yield* Ref.get(compilation);
 
@@ -152,7 +154,7 @@ export const makeDevGenerationStore = Effect.fnUntraced(function* (options: DevG
         yield* Deferred.succeed(current, ready.generation);
       }
     }
-  });
+  }, Effect.uninterruptible);
   const httpEffect = Ref.get(compilation).pipe(
     Effect.flatMap(Deferred.await),
     Effect.flatMap((ready) => ready.httpEffect),
@@ -233,15 +235,35 @@ export const makeDevApplication = Effect.fnUntraced(function* ({
         );
       }
     }
-  });
-  const watch = rspack
-    .watch(
-      makeRspackDevConfig(applicationRoot, entries, {
-        onCompilationStart: channel.onCompilationStart,
-        onServerComponentChanges: channel.onServerComponentChanges,
-      }),
-    )
-    .pipe(Stream.runForEach(update));
+  }, Effect.uninterruptible);
+  const watch = Effect.scoped(
+    Effect.gen(function* () {
+      const startup = yield* FiberHandle.make<void, DevGenerationFailure>();
+      const events = rspack
+        .watch(
+          makeRspackDevConfig(applicationRoot, entries, {
+            onCompilationStart: channel.onCompilationStart,
+            onServerComponentChanges: channel.onServerComponentChanges,
+          }),
+        )
+        .pipe(
+          Stream.runForEach(
+            Effect.fnUntraced(function* (event) {
+              // Finish obsolete startup cleanup before handling the next build event.
+              yield* FiberHandle.clear(startup);
+              if (event._tag === 'Compiled') {
+                yield* FiberHandle.run(startup, update(event), { startImmediately: true });
+              } else {
+                yield* update(event);
+              }
+            }),
+          ),
+          Effect.andThen(FiberHandle.awaitEmpty(startup)),
+        );
+
+      yield* Effect.raceFirst(events, FiberHandle.join(startup));
+    }),
+  );
   const httpEffect = yield* HttpRouter.toHttpEffect(
     HttpRouter.addAll([
       HttpRouter.route('GET', DevChannelPath, channel.httpEffect),

--- a/packages/effective-rsc/tests/build/dev.test.ts
+++ b/packages/effective-rsc/tests/build/dev.test.ts
@@ -11,6 +11,7 @@ import {
   Layer,
   Logger,
   Path,
+  Queue,
   Ref,
   Schedule,
   Scope,
@@ -29,7 +30,7 @@ import {
   makeDevGenerationStore,
 } from '../../src/build/dev';
 import { makeDevChannel } from '../../src/build/dev-channel';
-import { Rspack, RspackError } from '../../src/build/rspack';
+import { Rspack, RspackError, type RspackWatchEvent } from '../../src/build/rspack';
 import { Terminal } from '../../src/build/terminal';
 import { DevChannelPath, DevRpcs } from '../../src/dev/channel';
 
@@ -55,6 +56,14 @@ const serverBundleSource = (httpLayer: string) => `
   export const HttpLayer = ${httpLayer};
   export const ServerLayer = Layer.empty;
 `;
+
+const stalledServerBundleSource = (closedPath: string) =>
+  serverBundleSource(`Layer.effectDiscard(Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* Effect.addFinalizer(() => fs.writeFileString(${JSON.stringify(closedPath)}, 'closed').pipe(Effect.orDie));
+    yield* Effect.logInfo('startup entered');
+    yield* Effect.never;
+  }))`);
 
 it.effect('acquires a complete development generation before returning it', () =>
   Effect.gen(function* () {
@@ -394,6 +403,87 @@ it.effect('interrupts a candidate whose application startup never completes', ()
   }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
 );
 
+it.effect('loads a corrected compilation after the previous application startup stalls', () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const directory = yield* fileSystem.makeTempDirectoryScoped({ prefix: 'ersc-dev-recovery-' });
+    const closedPath = path.join(directory, 'startup-closed');
+    yield* fileSystem.writeFileString(
+      path.join(directory, 'stalled.js'),
+      stalledServerBundleSource(closedPath),
+    );
+    yield* fileSystem.writeFileString(
+      path.join(directory, 'corrected.js'),
+      serverBundleSource("HttpRouter.add('GET', '/corrected', HttpServerResponse.empty())"),
+    );
+
+    const events = yield* Queue.unbounded<RspackWatchEvent>();
+    const RspackLayer = Layer.succeed(
+      Rspack,
+      Rspack.of({ build: () => Effect.void, watch: () => Stream.fromQueue(events) }),
+    );
+    const startupEntered = yield* Deferred.make<void>();
+    const StartupLogger = Logger.layer([
+      Logger.make(({ message }) => {
+        if (Array.isArray(message) && message[0] === 'startup entered') {
+          Deferred.doneUnsafe(startupEntered, Exit.void);
+        }
+      }),
+    ]);
+    const application = yield* makeDevApplication({
+      hostname: 'localhost',
+      port: 18193,
+      root: directory,
+    }).pipe(Effect.provide(RspackLayer));
+    yield* application.watch.pipe(Effect.provide(StartupLogger), Effect.forkScoped());
+
+    yield* Queue.offer(events, { _tag: 'Building', changedFiles: [] });
+    yield* Queue.offer(events, {
+      _tag: 'Compiled',
+      ...CompilationDetails,
+      hash: 'stalled',
+      serverBundle: { filename: 'stalled.js', outputPath: directory },
+    });
+    yield* Deferred.await(startupEntered);
+
+    // This request is already waiting when the developer saves the correction.
+    const request = yield* application.httpEffect.pipe(
+      Effect.provideService(
+        HttpServerRequest.HttpServerRequest,
+        HttpServerRequest.fromWeb(new Request('http://localhost/corrected')),
+      ),
+      Effect.forkScoped({ startImmediately: true }),
+    );
+    expect(request.pollUnsafe()).toBeUndefined();
+
+    yield* Queue.offer(events, { _tag: 'Building', changedFiles: ['src/application.tsx'] });
+    // Rebuilding cancels startup, but requests keep waiting for the new outcome.
+    yield* fileSystem
+      .exists(closedPath)
+      .pipe(
+        Effect.repeat({ until: (closed) => closed, schedule: Schedule.spaced('5 millis') }),
+        Effect.timeout('1 second'),
+        TestClock.withLive,
+      );
+    expect(request.pollUnsafe()).toBeUndefined();
+    yield* Queue.offer(events, {
+      _tag: 'Compiled',
+      ...CompilationDetails,
+      hash: 'corrected',
+      serverBundle: { filename: 'corrected.js', outputPath: directory },
+    });
+
+    const response = yield* Fiber.join(request).pipe(
+      Effect.timeout('1 second'),
+      TestClock.withLive,
+    );
+    const closed = yield* fileSystem.readFileString(closedPath);
+    expect(response.status).toBe(204);
+    expect(closed).toBe('closed');
+  }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
+);
+
 it.effect('continues watching after a generation fails to start', () =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
@@ -411,26 +501,31 @@ it.effect('continues watching after a generation fails to start', () =>
       serverBundleSource("HttpRouter.add('GET', '/ready', HttpServerResponse.empty())"),
     );
 
+    const failureReported = yield* Deferred.make<void>();
     const RspackLayer = Layer.succeed(
       Rspack,
       Rspack.of({
         build: () => Effect.void,
         watch: () =>
-          Stream.make(
-            { _tag: 'Building', changedFiles: [] },
-            {
-              _tag: 'Compiled',
-              ...CompilationDetails,
-              hash: 'failed',
-              serverBundle: { filename: failedFilename, outputPath: directory },
-            },
-            { _tag: 'Building', changedFiles: [] },
-            {
-              _tag: 'Compiled',
-              ...CompilationDetails,
-              hash: 'ready',
-              serverBundle: { filename: readyFilename, outputPath: directory },
-            },
+          Stream.callback<RspackWatchEvent>(
+            Effect.fnUntraced(function* (queue) {
+              yield* Queue.offer(queue, { _tag: 'Building', changedFiles: [] });
+              yield* Queue.offer(queue, {
+                _tag: 'Compiled',
+                ...CompilationDetails,
+                hash: 'failed',
+                serverBundle: { filename: failedFilename, outputPath: directory },
+              });
+              yield* Deferred.await(failureReported);
+              yield* Queue.offer(queue, { _tag: 'Building', changedFiles: [] });
+              yield* Queue.offer(queue, {
+                _tag: 'Compiled',
+                ...CompilationDetails,
+                hash: 'ready',
+                serverBundle: { filename: readyFilename, outputPath: directory },
+              });
+              yield* Queue.end(queue);
+            }),
           ),
       }),
     );
@@ -438,6 +533,9 @@ it.effect('continues watching after a generation fails to start', () =>
     const TestLoggerLayer = Logger.layer([
       Logger.make(({ message }) => {
         messages.push(message);
+        if (Array.isArray(message) && message[0]?._tag === 'DevGenerationError') {
+          Deferred.doneUnsafe(failureReported, Exit.void);
+        }
       }),
     ]);
     const application = yield* makeDevApplication({
@@ -523,6 +621,7 @@ it.effect('keeps one HTTP server across successful generations', () =>
 
     const serverStarted = yield* Deferred.make<void>();
     const serverStopped = yield* Deferred.make<void>();
+    const firstReady = yield* Deferred.make<void>();
     const serveCount = yield* Ref.make(0);
     const HttpServerLayer = Layer.succeed(
       HttpServer.HttpServer,
@@ -541,33 +640,26 @@ it.effect('keeps one HTTP server across successful generations', () =>
       Rspack.of({
         build: () => Effect.void,
         watch: () =>
-          Stream.unwrap(
-            Deferred.await(serverStarted).pipe(
-              Effect.as(
-                Stream.make(
-                  { _tag: 'Building', changedFiles: [] },
-                  {
-                    _tag: 'Compiled',
-                    ...CompilationDetails,
-                    hash: 'first',
-                    serverBundle: {
-                      filename: firstFilename,
-                      outputPath: directory,
-                    },
-                  },
-                  { _tag: 'Building', changedFiles: [] },
-                  {
-                    _tag: 'Compiled',
-                    ...CompilationDetails,
-                    hash: 'second',
-                    serverBundle: {
-                      filename: secondFilename,
-                      outputPath: directory,
-                    },
-                  },
-                ),
-              ),
-            ),
+          Stream.callback<RspackWatchEvent>(
+            Effect.fnUntraced(function* (queue) {
+              yield* Deferred.await(serverStarted);
+              yield* Queue.offer(queue, { _tag: 'Building', changedFiles: [] });
+              yield* Queue.offer(queue, {
+                _tag: 'Compiled',
+                ...CompilationDetails,
+                hash: 'first',
+                serverBundle: { filename: firstFilename, outputPath: directory },
+              });
+              yield* Deferred.await(firstReady);
+              yield* Queue.offer(queue, { _tag: 'Building', changedFiles: [] });
+              yield* Queue.offer(queue, {
+                _tag: 'Compiled',
+                ...CompilationDetails,
+                hash: 'second',
+                serverBundle: { filename: secondFilename, outputPath: directory },
+              });
+              yield* Queue.end(queue);
+            }),
           ),
       }),
     );
@@ -578,15 +670,13 @@ it.effect('keeps one HTTP server across successful generations', () =>
       root: directory,
     }).pipe(Effect.provide(RspackLayer));
 
-    const logFiberIds: Array<number> = [];
+    const readyMessages: Array<string> = [];
     const TestLoggerLayer = Logger.layer([
-      Logger.make(({ fiber, message }) => {
+      Logger.make(({ message }) => {
         const text = Array.isArray(message) ? message[0] : message;
-        if (
-          typeof text === 'string' &&
-          (text.includes('effective-rsc') || text.includes('Compiling'))
-        ) {
-          logFiberIds.push(fiber.id);
+        if (typeof text === 'string' && text.includes('Ready')) {
+          readyMessages.push(text);
+          Deferred.doneUnsafe(firstReady, Exit.void);
         }
       }),
     ]);
@@ -599,7 +689,7 @@ it.effect('keeps one HTTP server across successful generations', () =>
     const stopped = yield* Deferred.isDone(serverStopped);
     expect(served).toBe(1);
     expect(stopped).toBe(true);
-    expect(new Set(logFiberIds)).toHaveLength(1);
+    expect(readyMessages).toHaveLength(2);
   }).pipe(Effect.provide(BunServices.layer), Effect.scoped),
 );
 


### PR DESCRIPTION
A stalled application startup used to block the dev watcher, so correcting the source still required a server restart. The watcher now cancels the stalled startup, waits for cleanup, and loads the corrected application. Requests already waiting for startup continue with the replacement.

Adds unit and E2E recovery coverage. The E2E restores its watched source once and waits for startup cleanup before removing its temporary files, including when an assertion fails.

Validation: the regression failed before the fix. Root `bun run check`, `bun run build`, and `bun run test` passed on this branch. A temporary E2E with an intentional assertion failure also confirmed that the source is restored and the marker directory is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development server recovery when application startup stalls. Correcting the source now interrupts the pending startup cleanly and loads the new compilation.
  - Requests waiting for startup continue waiting for the replacement compilation instead of becoming stuck.
  - Development watching continues after a generation fails to start, while keeping the existing HTTP server available across successful rebuilds.

- **Documentation**
  - Updated architecture documentation to explain development rebuild and startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->