### PR TITLE
test: reject stale transitions and verify request isolation

### DIFF
--- a/fixtures/framework-e2e/e2e/development-build-diagnostics.spec.ts
+++ b/fixtures/framework-e2e/e2e/development-build-diagnostics.spec.ts
@@ -4,7 +4,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 
 import { expect, test } from '@playwright/test';
 
-import { observeViewTransitions, waitForViewTransition } from './support/view-transitions';
+import { expectViewTransition, observeViewTransitions } from './support/view-transitions';
 
 const homePath = new URL('../src/modules/fixture/components/fixture-home.tsx', import.meta.url);
 
@@ -24,8 +24,11 @@ test('keeps build diagnostics after a cached navigation commits', async ({
   try {
     await writeFile(homePath, `${original}\nexport const broken = ;\n`);
     await expect(panel.getByRole('heading', { name: 'Build failed' })).toBeVisible();
-    await page.evaluate(() => navigation.back().finished);
-    await waitForViewTransition(page, ['navigation', 'navigation-traverse', 'navigation-backward']);
+    await expectViewTransition(
+      page,
+      ['navigation', 'navigation-traverse', 'navigation-backward'],
+      () => page.evaluate(() => navigation.back().finished),
+    );
     await expect(page).toHaveURL('/');
     await expect(
       page.getByRole('button', { name: 'Probe count: 0', includeHidden: true }),

--- a/fixtures/framework-e2e/e2e/flight.spec.ts
+++ b/fixtures/framework-e2e/e2e/flight.spec.ts
@@ -37,8 +37,14 @@ test('serves the complete application route tree through the native Flight proto
 
 test('isolates ERSC runtimes across concurrent Flight requests', async ({ request }) => {
   const [primary, secondary] = await Promise.all([
-    requestFlight(request),
-    requestFlight(request, '/catalog/secondary'),
+    getText(request, '/catalog/primary', {
+      accept: 'text/x-component',
+      cookie: 'fixture-actor=Alice',
+    }),
+    getText(request, '/catalog/secondary', {
+      accept: 'text/x-component',
+      cookie: 'fixture-actor=Bob',
+    }),
   ]);
 
   expect(primary.response.status()).toBe(200);
@@ -49,4 +55,17 @@ test('isolates ERSC runtimes across concurrent Flight requests', async ({ reques
   expect(secondary.body).toContain('Secondary catalog');
   expect(secondary.body).toContain('Secondary detail A');
   expect(secondary.body).not.toContain('Primary detail A');
+  expect(primary.body).toContain(JSON.stringify(['Personalized for ', 'Alice']));
+  expect(primary.body).not.toContain(JSON.stringify(['Personalized for ', 'Bob']));
+  expect(secondary.body).toContain(JSON.stringify(['Personalized for ', 'Bob']));
+  expect(secondary.body).not.toContain(JSON.stringify(['Personalized for ', 'Alice']));
+
+  // Confirm the requests overlapped during their asynchronous catalog queries.
+  const queries = [primary, secondary].map(({ body }) => ({
+    startedAt: Number(body.match(/"data-catalog-started-at":(\d+)/)?.[1]),
+    completedAt: Number(body.match(/"data-catalog-completed-at":(\d+)/)?.[1]),
+  }));
+  expect(Math.max(...queries.map((query) => query.startedAt))).toBeLessThan(
+    Math.min(...queries.map((query) => query.completedAt)),
+  );
 });

--- a/fixtures/framework-e2e/e2e/navigation.spec.ts
+++ b/fixtures/framework-e2e/e2e/navigation.spec.ts
@@ -2,7 +2,7 @@
 import { expect, test, type Request } from '@playwright/test';
 
 import { observeBrowserErrors } from './support/browser-errors';
-import { observeViewTransitions, waitForViewTransition } from './support/view-transitions';
+import { expectViewTransition, observeViewTransitions } from './support/view-transitions';
 
 const isNavigationFlightRequest = (request: Request) =>
   request.method() === 'GET' && request.headers()['accept'] === 'text/x-component';
@@ -31,29 +31,34 @@ test('moves between route groups through the composed catalog', async ({ page })
       new URL(request.url()).pathname === '/catalog/secondary' &&
       isNavigationFlightRequest(request),
   );
-  const navigationStartedAtScrollY = await secondaryNavigation.evaluate(
-    (element: HTMLAnchorElement) => {
-      window.scrollTo(0, document.documentElement.scrollHeight);
-      element.focus({ preventScroll: true });
-      const scrollY = window.scrollY;
-      element.click();
-      return scrollY;
+  await expectViewTransition(
+    page,
+    ['navigation', 'navigation-push', 'navigation-forward'],
+    async () => {
+      const navigationStartedAtScrollY = await secondaryNavigation.evaluate(
+        (element: HTMLAnchorElement) => {
+          window.scrollTo(0, document.documentElement.scrollHeight);
+          element.focus({ preventScroll: true });
+          const scrollY = window.scrollY;
+          element.click();
+          return scrollY;
+        },
+      );
+      expect(navigationStartedAtScrollY).toBeGreaterThan(0);
+      // The destination page deliberately takes two seconds. Loading must commit from the streamed
+      // route shell rather than appearing only after the page row has resolved.
+      await expect(page.getByRole('main', { name: 'Loading catalog' })).toBeVisible({
+        timeout: 1_500,
+      });
+      await expect(page).toHaveURL('/catalog/secondary');
+      await expect(page.getByRole('heading', { level: 1, name: 'Primary catalog' })).toBeHidden();
+      await expect(page.getByRole('heading', { level: 1, name: 'Secondary catalog' })).toBeHidden();
+      await page.waitForFunction(() => window.navigation.transition === null);
+      await expect(page.locator('body')).toBeFocused();
+      // This covers the current forward-navigation reset, not history restoration for streamed UI.
+      expect(await page.evaluate(() => window.scrollY)).toBe(0);
     },
   );
-  expect(navigationStartedAtScrollY).toBeGreaterThan(0);
-  // The destination page deliberately takes two seconds. Loading must commit from the streamed
-  // route shell rather than appearing only after the page row has resolved.
-  await expect(page.getByRole('main', { name: 'Loading catalog' })).toBeVisible({
-    timeout: 1_500,
-  });
-  await expect(page).toHaveURL('/catalog/secondary');
-  await expect(page.getByRole('heading', { level: 1, name: 'Primary catalog' })).toBeHidden();
-  await expect(page.getByRole('heading', { level: 1, name: 'Secondary catalog' })).toBeHidden();
-  await page.waitForFunction(() => window.navigation.transition === null);
-  await expect(page.locator('body')).toBeFocused();
-  // This covers the current forward-navigation reset, not history restoration for streamed UI.
-  expect(await page.evaluate(() => window.scrollY)).toBe(0);
-  await waitForViewTransition(page, ['navigation', 'navigation-push', 'navigation-forward']);
   expect(navigationFlightFinished).toBe(false);
   await flightRequest;
 
@@ -79,24 +84,30 @@ test('publishes native link types once without replaying them on history travers
     child.textContent = 'Nested link content';
     element.append(child);
   });
-  await link.getByText('Nested link content').click();
-  await expect(page).toHaveURL('/catalog/secondary');
-  await waitForViewTransition(page, [
-    'navigation',
-    'navigation-push',
-    'navigation-forward',
-    'docs-previous',
-    'section-change',
-  ]);
+  await expectViewTransition(
+    page,
+    ['navigation', 'navigation-push', 'navigation-forward', 'docs-previous', 'section-change'],
+    async () => {
+      await link.getByText('Nested link content').click();
+      await expect(page).toHaveURL('/catalog/secondary');
+    },
+  );
   await expect(page.locator('[data-detail-id="secondary-slow-stream"]')).toBeVisible();
 
-  await page.evaluate(() => window.navigation.back().finished);
-  await waitForViewTransition(page, ['navigation', 'navigation-traverse', 'navigation-backward']);
-  await page.evaluate(() => window.navigation.forward().finished);
-  await waitForViewTransition(page, ['navigation', 'navigation-traverse', 'navigation-forward']);
+  await expectViewTransition(
+    page,
+    ['navigation', 'navigation-traverse', 'navigation-backward'],
+    () => page.evaluate(() => window.navigation.back().finished),
+  );
+  await expectViewTransition(
+    page,
+    ['navigation', 'navigation-traverse', 'navigation-forward'],
+    () => page.evaluate(() => window.navigation.forward().finished),
+  );
 
-  await page.evaluate(() => window.navigation.navigate('/catalog/primary').finished);
-  await waitForViewTransition(page, ['navigation', 'navigation-push', 'navigation-forward']);
+  await expectViewTransition(page, ['navigation', 'navigation-push', 'navigation-forward'], () =>
+    page.evaluate(() => window.navigation.navigate('/catalog/primary').finished),
+  );
   expect(browserErrors).toEqual([]);
 });
 
@@ -105,12 +116,12 @@ test('types a replace navigation without inventing a direction', async ({ page }
   await observeViewTransitions(page);
   await page.goto('/catalog/primary');
 
-  await page.evaluate(
-    () => window.navigation.navigate('/catalog/secondary', { history: 'replace' }).finished,
-  );
-
-  await expect(page).toHaveURL('/catalog/secondary');
-  await waitForViewTransition(page, ['navigation', 'navigation-replace']);
+  await expectViewTransition(page, ['navigation', 'navigation-replace'], async () => {
+    await page.evaluate(
+      () => window.navigation.navigate('/catalog/secondary', { history: 'replace' }).finished,
+    );
+    await expect(page).toHaveURL('/catalog/secondary');
+  });
   expect(browserErrors).toEqual([]);
 });
 
@@ -131,13 +142,25 @@ test('reuses completed route trees for back and forward navigation', async ({ pa
   await expect(page.getByRole('heading', { level: 1, name: 'Secondary catalog' })).toBeVisible();
   await expect(page.locator('[data-detail-id="secondary-slow-stream"]')).toBeVisible();
 
-  await page.evaluate(() => window.navigation.back().finished);
-  await expect(page.getByRole('heading', { level: 1, name: 'Primary catalog' })).toBeVisible();
-  await waitForViewTransition(page, ['navigation', 'navigation-traverse', 'navigation-backward']);
+  await expectViewTransition(
+    page,
+    ['navigation', 'navigation-traverse', 'navigation-backward'],
+    async () => {
+      await page.evaluate(() => window.navigation.back().finished);
+      await expect(page.getByRole('heading', { level: 1, name: 'Primary catalog' })).toBeVisible();
+    },
+  );
 
-  await page.evaluate(() => window.navigation.forward().finished);
-  await expect(page.getByRole('heading', { level: 1, name: 'Secondary catalog' })).toBeVisible();
-  await waitForViewTransition(page, ['navigation', 'navigation-traverse', 'navigation-forward']);
+  await expectViewTransition(
+    page,
+    ['navigation', 'navigation-traverse', 'navigation-forward'],
+    async () => {
+      await page.evaluate(() => window.navigation.forward().finished);
+      await expect(
+        page.getByRole('heading', { level: 1, name: 'Secondary catalog' }),
+      ).toBeVisible();
+    },
+  );
 
   expect(flightRequests).toEqual(['/catalog/secondary']);
   expect(browserErrors).toEqual([]);

--- a/fixtures/framework-e2e/e2e/routing.spec.ts
+++ b/fixtures/framework-e2e/e2e/routing.spec.ts
@@ -3,9 +3,11 @@ import { expect, test } from '@playwright/test';
 
 import { getText } from './support/http';
 
-test('renders every declared route as HTML and Flight', async ({ request }) => {
-  const html = await getText(request, '/catalog/secondary?source=integration');
-  const flight = await getText(request, '/catalog/secondary', { accept: 'text/x-component' });
+test('renders the same catalog route as HTML and Flight', async ({ request }) => {
+  const [html, flight] = await Promise.all([
+    getText(request, '/catalog/secondary?source=integration'),
+    getText(request, '/catalog/secondary', { accept: 'text/x-component' }),
+  ]);
 
   expect(html.response.status()).toBe(200);
   expect(html.body).toContain('<title>ERSC Framework Fixture — Integration contracts</title>');
@@ -19,8 +21,10 @@ test('renders every declared route as HTML and Flight', async ({ request }) => {
 });
 
 test('renders a parameter-free Page at the application root', async ({ request }) => {
-  const html = await getText(request, '/');
-  const flight = await getText(request, '/', { accept: 'text/x-component' });
+  const [html, flight] = await Promise.all([
+    getText(request, '/'),
+    getText(request, '/', { accept: 'text/x-component' }),
+  ]);
 
   expect(html.response.status()).toBe(200);
   expect(html.body).toContain('<title>ERSC Framework Fixture — Integration contracts</title>');
@@ -37,8 +41,10 @@ test('renders a parameter-free Page at the application root', async ({ request }
 });
 
 test('retains the native router response for unknown paths', async ({ request }) => {
-  const html = await getText(request, '/missing');
-  const flight = await getText(request, '/missing', { accept: 'text/x-component' });
+  const [html, flight] = await Promise.all([
+    getText(request, '/missing'),
+    getText(request, '/missing', { accept: 'text/x-component' }),
+  ]);
 
   expect(html.response.status()).toBe(404);
   expect(html.body).toBe('');

--- a/fixtures/framework-e2e/e2e/server-functions.spec.ts
+++ b/fixtures/framework-e2e/e2e/server-functions.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 
 import { observeBrowserErrors } from './support/browser-errors';
 import { itemCard, setItemSelection } from './support/catalog-page';
-import { observeViewTransitions, waitForViewTransition } from './support/view-transitions';
+import { expectViewTransition, observeViewTransitions } from './support/view-transitions';
 
 const observeCatalogFallback = (page: Parameters<typeof observeBrowserErrors>[0]) =>
   page.evaluate(() => {
@@ -48,23 +48,25 @@ test.describe('Server Functions', () => {
     try {
       let item = itemCard(page, title);
       await observeCatalogFallback(page);
-      await item.getByRole('button', { name: 'Add to the selection' }).click();
-
-      await expect(item.getByText("Added to Integration Actor's selection.")).toBeVisible();
-      await expect(item.getByRole('button', { name: 'Remove from the selection' })).toBeVisible();
-      await waitForViewTransition(page, ['server-function']);
+      await expectViewTransition(page, ['server-function'], async () => {
+        await item.getByRole('button', { name: 'Add to the selection' }).click();
+        await expect(item.getByText("Added to Integration Actor's selection.")).toBeVisible();
+        await expect(item.getByRole('button', { name: 'Remove from the selection' })).toBeVisible();
+      });
       const selection = page.locator('section[aria-labelledby="fixture-selection-heading"]');
       await expect(selection).not.toContainText(title);
       await expect(selection).toContainText(title);
       expect(await readCatalogFallbackObservation(page)).toBe(false);
 
       // The second submission sends the previous result object, not the initial null state.
-      await item.getByRole('button', { name: 'Remove from the selection' }).click();
-      await expect(item.getByText("Removed from Integration Actor's selection.")).toBeVisible();
-      await waitForViewTransition(page, ['server-function']);
-      await item.getByRole('button', { name: 'Add to the selection' }).click();
-      await expect(item.getByText("Added to Integration Actor's selection.")).toBeVisible();
-      await waitForViewTransition(page, ['server-function']);
+      await expectViewTransition(page, ['server-function'], async () => {
+        await item.getByRole('button', { name: 'Remove from the selection' }).click();
+        await expect(item.getByText("Removed from Integration Actor's selection.")).toBeVisible();
+      });
+      await expectViewTransition(page, ['server-function'], async () => {
+        await item.getByRole('button', { name: 'Add to the selection' }).click();
+        await expect(item.getByText("Added to Integration Actor's selection.")).toBeVisible();
+      });
 
       await page.reload();
       item = itemCard(page, title);

--- a/fixtures/framework-e2e/e2e/support/view-transitions.ts
+++ b/fixtures/framework-e2e/e2e/support/view-transitions.ts
@@ -1,3 +1,4 @@
+// oxlint-disable effecttsgo/async-function -- Playwright owns this Promise-based browser-test boundary.
 import { expect, type Page } from '@playwright/test';
 
 type ViewTransitionObservation = {
@@ -36,10 +37,27 @@ export const observeViewTransitions = (page: Page) =>
     });
   });
 
-export const waitForViewTransition = (page: Page, types: ReadonlyArray<string>) =>
-  expect
+export const expectViewTransition = async (
+  page: Page,
+  types: ReadonlyArray<string>,
+  action: () => Promise<unknown>,
+) => {
+  const start = await page.evaluate(
+    () =>
+      (Reflect.get(window, '__ersc_view_transitions__') as Array<ViewTransitionObservation>).length,
+  );
+  await action();
+  await expect
     .poll(
-      () => page.evaluate(() => JSON.stringify(Reflect.get(window, '__ersc_view_transitions__'))),
+      () =>
+        page.evaluate(
+          (start) =>
+            (
+              Reflect.get(window, '__ersc_view_transitions__') as Array<ViewTransitionObservation>
+            ).slice(start),
+          start,
+        ),
       { timeout: 3_000 },
     )
-    .toContain(JSON.stringify({ status: 'Finished', types }));
+    .toContainEqual({ status: 'Finished', types });
+};

--- a/fixtures/framework-e2e/e2e/view-transition-observer.spec.ts
+++ b/fixtures/framework-e2e/e2e/view-transition-observer.spec.ts
@@ -1,0 +1,49 @@
+// oxlint-disable effecttsgo/async-function -- Playwright owns this Promise-based browser-test boundary.
+import { expect, test } from '@playwright/test';
+
+import { expectViewTransition, observeViewTransitions } from './support/view-transitions';
+
+test.beforeEach(async ({ page }) => {
+  await observeViewTransitions(page);
+  await page.goto('about:blank');
+  await expectViewTransition(page, ['probe'], () =>
+    page.evaluate(
+      () =>
+        document.startViewTransition({
+          types: ['probe'],
+          update: () => {
+            document.body.textContent = 'First action';
+          },
+        }).finished,
+    ),
+  );
+});
+
+test('an earlier transition cannot satisfy an action that starts no transition', async ({
+  page,
+}) => {
+  await expect(
+    expectViewTransition(page, ['probe'], () =>
+      page.evaluate(() => {
+        document.body.textContent = 'Action without a transition';
+      }),
+    ),
+  ).rejects.toThrow();
+});
+
+test('an earlier transition cannot hide a rejected transition from the next action', async ({
+  page,
+}) => {
+  await expect(
+    expectViewTransition(page, ['probe'], () =>
+      page.evaluate(() => {
+        const transition = document.startViewTransition({
+          types: ['probe'],
+          update: () => Promise.reject(new Error('Transition update failed')),
+        });
+        void transition.ready.catch(() => {});
+        return transition.finished.catch(() => {});
+      }),
+    ),
+  ).rejects.toThrow();
+});


### PR DESCRIPTION
The transition waiter could pass using a transition from an earlier action. It now records the observation count before running each action and checks only newer transitions. Browser regressions cover an action that starts no transition and one whose transition rejects.

The concurrent Flight test now uses different actor cookies, checks that neither response contains the other actor, and verifies that the requests overlapped. Independent HTML and Flight requests also run together; the catalog routing test takes about 5 seconds per mode instead of 10.

Validation: root `bun run check`, `bun run build`, and `bun run test` passed. Both transition regressions failed against the old waiter. A temporary shared-actor mutation passed the old isolation assertions and failed the strengthened test.
