### PR TITLE
chore: prepare 0.1.4 release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,7 @@
     },
     "packages/create-ersc-app": {
       "name": "create-ersc-app",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "bin": {
         "create-ersc-app": "./bin/create-ersc-app.js",
       },
@@ -117,7 +117,7 @@
     },
     "packages/effective-rsc": {
       "name": "effective-rsc",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "bin": {
         "ersc": "./bin/ersc.js",
       },
@@ -155,7 +155,7 @@
     },
     "packages/vercel": {
       "name": "@ersc/vercel",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@vercel/nft": "1.11.0",
       },

--- a/packages/create-ersc-app/package.json
+++ b/packages/create-ersc-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-ersc-app",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Scaffold an effective-rsc application with Bun",
   "keywords": [
     "bun",

--- a/packages/create-ersc-app/template/package.json
+++ b/packages/create-ersc-app/template/package.json
@@ -13,7 +13,7 @@
     "@effect/platform-browser": "4.0.0-rc.113",
     "@effect/platform-bun": "4.0.0-rc.113",
     "effect": "4.0.0-rc.113",
-    "effective-rsc": "0.1.3",
+    "effective-rsc": "0.1.4",
     "react": "19.3.0-canary-1d34f91d-20260909",
     "react-dom": "19.3.0-canary-1d34f91d-20260909",
     "react-server-dom-rspack": "0.1.0"

--- a/packages/effective-rsc/package.json
+++ b/packages/effective-rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "effective-rsc",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "An experimental, Effect-native React Server Components framework for Bun.",
   "keywords": [
     "bun",

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ersc/vercel",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Vercel deployment adapter for effective-rsc",
   "keywords": [
     "bun",


### PR DESCRIPTION
## Summary

Prepare the publishable packages for the 0.1.4 release.

- Bump `effective-rsc`, `@ersc/vercel`, and `create-ersc-app` to `0.1.4`.
- Update the `create-ersc-app` template dependency and Bun lockfile.

## Verification

- `bun run check`
- `bun run build`
- `bun run test`
- Package publish dry-runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Released version 0.1.4 across the related packages.
  - Updated the app template to use the 0.1.4 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->